### PR TITLE
[!!!][TASK] Adjust to search API changes in TYPO3CR

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexingManager.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexingManager.php
@@ -14,7 +14,7 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception;
 use Flowpack\ElasticSearch\Domain\Model\Client;
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\TYPO3CR\Domain\Model\NodeData;
+use TYPO3\TYPO3CR\Domain\Model\Node;
 
 /**
  * Indexer for Content Repository Nodes. Manages an indexing queue to allow for deferred indexing.
@@ -64,12 +64,12 @@ class NodeIndexingManager {
 	/**
 	 * Schedule a node for indexing
 	 *
-	 * @param NodeData $nodeData
+	 * @param Node $node
 	 * @return void
 	 */
-	public function indexNode(NodeData $nodeData) {
-		$this->nodesToBeRemoved->detach($nodeData);
-		$this->nodesToBeIndexed->attach($nodeData);
+	public function indexNode(Node $node) {
+		$this->nodesToBeRemoved->detach($node);
+		$this->nodesToBeIndexed->attach($node);
 
 		$this->flushQueuesIfNeeded();
 	}
@@ -77,18 +77,19 @@ class NodeIndexingManager {
 	/**
 	 * Schedule a node for removal of the index
 	 *
-	 * @param NodeData $nodeData
+	 * @param Node $node
 	 * @return void
 	 */
-	public function removeNode(NodeData $nodeData) {
-		$this->nodesToBeIndexed->detach($nodeData);
-		$this->nodesToBeRemoved->attach($nodeData);
+	public function removeNode(Node $node) {
+		$this->nodesToBeIndexed->detach($node);
+		$this->nodesToBeRemoved->attach($node);
 
 		$this->flushQueuesIfNeeded();
 	}
 
 	/**
-	 *
+	 * Flush the indexing/removal queues, actually processing them, if the
+	 * maximum indexing batch size has been reached.
 	 *
 	 * @return void
 	 */

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Package.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Package.php
@@ -38,14 +38,14 @@ class Package extends BasePackage {
 	}
 
 	/**
-	 * Registers slots for repository signals in order to be able to index nodes
+	 * Registers slots for signals in order to be able to index nodes
 	 *
 	 * @param Bootstrap $bootstrap
 	 */
 	public function registerIndexingSlots(Bootstrap $bootstrap) {
-		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'nodeAdded', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode');
-		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'nodeUpdated', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode');
-		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository', 'nodeRemoved', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'removeNode');
+		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeAdded', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode');
+		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeUpdated', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode');
+		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'removeNode');
 		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\Flow\Persistence\Doctrine\PersistenceManager', 'allObjectsPersisted', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'flushQueues');
 	}
 }

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -6,14 +6,6 @@
 
   properties:
 
-    '__persistenceObjectIdentifier':
-      elasticSearch:
-        mapping:
-          type: string
-          index: not_analyzed
-          include_in_all: false
-        indexing: '${persistenceObjectIdentifier}'
-
     '__identifier':
       elasticSearch:
         mapping:


### PR DESCRIPTION
- wire signals from Node instead of NodeDataRepository
- no longer index __persistenceObjectIdentifier
- change slots to accept Node instead of NodeData
- adjust NodeIndexer to work with Node instead of NodeData
- build Node instances for indexing in NodeIndexCommandController

With this change the id of all documents indexed in ES changes, so a
reindexing is needed.
