### PR TITLE
[TASK] Adjust to removal of ContextInterface

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Service/NodeSearchService.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Service/NodeSearchService.php
@@ -16,7 +16,7 @@ use Flowpack\ElasticSearch\Domain\Factory\ClientFactory;
 use Flowpack\ElasticSearch\Domain\Model\Client;
 use Flowpack\ElasticSearch\Domain\Model\Index;
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\TYPO3CR\Domain\Service\ContextInterface;
+use TYPO3\TYPO3CR\Domain\Service\Context;
 
 /**
  * Search service for TYPO3CR nodes
@@ -86,13 +86,13 @@ class NodeSearchService {
 	 *
 	 * @param string $nodePath Parent node path where search starts. All nodes below that path are considered.
 	 * @param string $sortingFieldName Name of the node property which is going to be used as a sorting criteria. Its value can be string, numeric or a date
-	 * @param \TYPO3\TYPO3CR\Domain\Service\ContextInterface $contentContext The content context, for example derived from the "current node"
+	 * @param \TYPO3\TYPO3CR\Domain\Service\Context $contentContext The content context, for example derived from the "current node"
 	 * @param integer $maximumResults The number of maximum results. If "1" is specified, this function will still return an array, but with 1 element.
 	 * @param integer $fromResult For pagination: the result number to start with. Index starts a 0.
 	 * @param string $nodeTypeFilter (currently) a single node type name to filter the results
 	 * @return array<\TYPO3\TYPO3CR\Domain\Model\Node>|NULL
 	 */
-	public function findRecent($nodePath, $sortingFieldName, ContextInterface $contentContext, $maximumResults = 100, $fromResult = NULL, $nodeTypeFilter = NULL) {
+	public function findRecent($nodePath, $sortingFieldName, Context $contentContext, $maximumResults = 100, $fromResult = NULL, $nodeTypeFilter = NULL) {
 		$searchQuery = array(
 			'query' => array(
 				'prefix' => array(

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -26,7 +26,7 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 	public function setUp() {
 		$node = $this->getMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
 		$node->expects($this->any())->method('getPath')->will($this->returnValue('/foo/bar'));
-		$mockContext = $this->getMock('TYPO3\TYPO3CR\Domain\Service\ContextInterface');
+		$mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
 		$node->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
 
 		$mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
The ContextInterface in TYPO3CR is removed, thus the code needs to be
adjusted.

See https://review.typo3.org/27868
