### PR TITLE
[BUGFIX] Node publishing does not trigger indexing

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Package.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Package.php
@@ -46,6 +46,7 @@ class Package extends BasePackage {
 		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeAdded', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode');
 		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeUpdated', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode');
 		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\TYPO3CR\Domain\Model\Node', 'nodeRemoved', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'removeNode');
+		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\Neos\Service\PublishingService', 'nodePublished', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'indexNode', FALSE);
 		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\Flow\Persistence\Doctrine\PersistenceManager', 'allObjectsPersisted', 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexingManager', 'flushQueues');
 	}
 }


### PR DESCRIPTION
Nodes being published are not indexed, because the signals in Node
are never emitted during publishing.

In addition the node coming from the PublishingService (through an
additional signal) never has the target workspace assigned, so it
is passed to the indexing as separate information.
