### PR TITLE
[BUGFIX] Trying to get property of non-object error

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -368,7 +368,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 			$responseAsLines = $this->getIndex()->request('POST', '/_bulk', array(), $content)->getOriginalResponse()->getContent();
 			foreach (explode('\n', $responseAsLines) as $responseLine) {
 				$response = json_decode($responseLine);
-				if ($response->errors !== FALSE) {
+				if (!is_object($response) || $response->errors !== FALSE) {
 					$this->logger->log('Indexing Error: ' . $responseLine, LOG_ERR);
 				}
 			}


### PR DESCRIPTION
During indexing I got a 'Trying to get property of non-object' error
in the NodeIndexer on a line that contained invalid json (a truncated
error message). This change makes sure an error is logged if invalid
json is returned.
