### PR TITLE
[BUGFIX] Catch empty error property on bulk json responses

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -368,7 +368,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 			$responseAsLines = $this->getIndex()->request('POST', '/_bulk', array(), $content)->getOriginalResponse()->getContent();
 			foreach (explode('\n', $responseAsLines) as $responseLine) {
 				$response = json_decode($responseLine);
-				if (!is_object($response) || $response->errors !== FALSE) {
+				if (!is_object($response) || (isset($response->errors) && $response->errors !== FALSE)) {
 					$this->logger->log('Indexing Error: ' . $responseLine, LOG_ERR);
 				}
 			}


### PR DESCRIPTION
This fails on bulk requests when the error property of the response object is not set
