### PR TITLE
[BUGFIX] Context workspace should be indexed

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -20,7 +20,7 @@
           type: string
           index: not_analyzed
           include_in_all: false
-        indexing: '${node.workspace.name}'
+        indexing: '${node.context.workspace.name}'
 
     '__path':
       search:


### PR DESCRIPTION
Indexed documents contained the workspace of the actual node and not of the context. This way workspace overrides did not work and all nodes shows up in the live workspace, when no workspace variant exists. That causes problems with duplicate entries and unreliable limit.
