### PR TITLE
[TASK] Use PHP 5.5 as minimum requirement

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -21,26 +21,6 @@ use TYPO3\TYPO3CR\Domain\Model\Node;
 use TYPO3\TYPO3CR\Domain\Service\NodeTypeManager;
 use TYPO3\TYPO3CR\Search\Indexer\AbstractNodeIndexer;
 
-/*
- * Yes, dirty as hell. But the function is just too helpful...
- * json_last_error_msg() has been added in PHP 5.5
- */
-if (!function_exists('json_last_error_msg')) {
-	function json_last_error_msg() {
-		static $errors = array(
-			JSON_ERROR_NONE => NULL,
-			JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
-			JSON_ERROR_STATE_MISMATCH => 'Underflow or the modes mismatch',
-			JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
-			JSON_ERROR_SYNTAX => 'Syntax error, malformed JSON',
-			JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded'
-		);
-		$error = json_last_error();
-
-		return array_key_exists($error, $errors) ? $errors[$error] : "Unknown error ({$error})";
-	}
-}
-
 /**
  * Indexer for Content Repository Nodes. Triggered from the NodeIndexingManager.
  *

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "homepage": "http://flowpack.org/",
     "license": ["LGPL-3.0+"],
     "require": {
+        "php": ">=5.5.0",
+
         "flowpack/elasticsearch": "*",
         "typo3/eel": "*",
         "typo3/typo3cr": "*",


### PR DESCRIPTION
Removes the user land definition of json_last_error_msg()