### PR TITLE
[BUGFIX] Handle response in NodeIndexing flushing correctly

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -368,7 +368,7 @@ class NodeIndexer extends AbstractNodeIndexer {
 
 		if ($content !== '') {
 			$responseAsLines = $this->getIndex()->request('POST', '/_bulk', array(), $content)->getOriginalResponse()->getContent();
-			foreach (explode('\n', $responseAsLines) as $responseLine) {
+			foreach (explode("\n", $responseAsLines) as $responseLine) {
 				$response = json_decode($responseLine);
 				if (!is_object($response) || (isset($response->errors) && $response->errors !== FALSE)) {
 					$this->logger->log('Indexing Error: ' . $responseLine, LOG_ERR);


### PR DESCRIPTION
Incorrect escaping of the newline character used in the flush method
in the NodeIndexing, resulting in incorrect log data if multiple
response lines were returned.