### PR TITLE
[FEATURE] ``queryFilterMultiple`` operation for QueryBuilder

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -330,6 +330,26 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
+	 * Add multiple filters to query.filtered.filter
+	 *
+	 * @param array $data An associative array of keys as variable names and values as variable values
+	 * @param string $clauseType one of must, should, must_not
+	 * @return ElasticSearchQueryBuilder
+	 */
+	public function queryFilterMultiple($data, $clauseType = 'must') {
+		foreach ($data as $key => $value) {
+			if ($value !== NULL) {
+				if (is_array($value)) {
+					$this->queryFilter('terms', array($key => $value), $clauseType);
+				} else {
+					$this->queryFilter('term', array($key => $value), $clauseType);
+				}
+			}
+		}
+		return $this;
+	}
+
+	/**
 	 * Get the ElasticSearch request as we need it
 	 *
 	 * @return array


### PR DESCRIPTION
Usage::

  searchFilter = TYPO3.TypoScript:RawArray {
    constraint1 = 'a'
    constraint2 = TYPO3.TypoScript:RawArray {
      0 = 'b'
      1 = 'c'
    }
  }

  searchQuery = ${Search.queryFilterMultiple(this.searchFilter)}