### PR TITLE
[!!!][FEATURE] Make search metadata available

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -361,7 +361,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	/**
 	 * Execute the query and return the list of nodes as result
 	 *
-	 * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>
+	 * @return array
 	 */
 	public function execute() {
 		$timeBefore = microtime(TRUE);
@@ -405,7 +405,10 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 			}
 			$node = $this->contextNode->getNode($nodePath);
 			if ($node instanceof NodeInterface) {
-				$nodes[$node->getIdentifier()] = $node;
+				$nodes[$node->getIdentifier()] = array(
+					'node' => $node,
+					'meta' => $hit
+				);
 				if ($this->limit > 0 && count($nodes) >= $this->limit) {
 					break;
 				}
@@ -416,7 +419,10 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 			$this->logger->log('Query Log (' . $this->logMessage . ') Number of returned results: ' . count($nodes), LOG_DEBUG);
 		}
 
-		return array_values($nodes);
+		return array(
+			'nodes' => array_values($nodes),
+			'response' => $response->getTreatedContent()
+		);
 	}
 
 	/**


### PR DESCRIPTION
Changes the return format of the execute method to return an array
with a ``nodes`` key containing an array of results. Each result
consists of a ``node`` key with the node instance and a ``meta`` key
containing metadata about the result. Additionally the metadata from
the whole request is available along ``nodes`` as ``response``.

This allows for additional metadata to be passed along, needed for display
of advanced results.

Example of output::

  array(
  	'nodes' => array(
  		array(
  			'node' => NodeInterface,
  			'meta' => array
  		),
  		array(
  			'node' => NodeInterface,
			'meta' => array
  		)
  	),
  	'response' => array
  )

Adjust existing code::

  searchQuery.execute() => searchQuery.execute().nodes

  ${q(node).*} 0> $q(result.node.*}