### PR TITLE
[FEATURE] Implement QueryResultInterface in execute()

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQuery.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQuery.php
@@ -1,9 +1,15 @@
 <?php
-/***************************************************************
- *  (c) 2014 networkteam GmbH - all rights reserved
- ***************************************************************/
-
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel;
+
+/*                                                                                                  *
+ * This script belongs to the TYPO3 Flow package "Flowpack.ElasticSearch.ContentRepositoryAdaptor". *
+ *                                                                                                  *
+ * It is free software; you can redistribute it and/or modify it under                              *
+ * the terms of the GNU Lesser General Public License, either version 3                             *
+ *  of the License, or (at your option) any later version.                                          *
+ *                                                                                                  *
+ * The TYPO3 project - inspiring people to share!                                                   *
+ *                                                                                                  */
 
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception;
 use TYPO3\Flow\Persistence\QueryInterface;
@@ -20,48 +26,23 @@ class ElasticSearchQuery implements QueryInterface {
 	}
 
 	/**
-	 * @param mixed $queryBuilder
-	 */
-	public function setQueryBuilder(ElasticSearchQueryBuilder $queryBuilder) {
-		$this->queryBuilder = $queryBuilder;
-	}
-
-	/**
-	 * @return ElasticSearchQueryBuilder
-	 */
-	public function getQueryBuilder() {
-		return $this->queryBuilder;
-	}
-
-	/**
-	 * Executes the query and returns the result.
-	 *
-	 * @param bool $cacheResult If the result cache should be used
-	 * @return \TYPO3\Flow\Persistence\QueryResultInterface The query result
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function execute($cacheResult = FALSE) {
 		return new ElasticSearchQueryResult($this);
 	}
 
 	/**
-	 * Returns the query result count.
-	 *
-	 * @return integer The query result count
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function count() {
+		// FIXME Check that results are fetched!
+
 		return $this->queryBuilder->getTotalItems();
 	}
 
 	/**
-	 * Sets the maximum size of the result set to limit. Returns $this to allow
-	 * for chaining (fluid interface).
-	 *
-	 * @param integer $limit
-	 * @return \TYPO3\Flow\Persistence\QueryInterface
-	 * @throws \InvalidArgumentException
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function setLimit($limit) {
 		if ($limit < 1 || !is_int($limit)) {
@@ -72,23 +53,14 @@ class ElasticSearchQuery implements QueryInterface {
 	}
 
 	/**
-	 * Returns the maximum size of the result set to limit.
-	 *
-	 * @return integer
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function getLimit() {
 		return $this->queryBuilder->getLimit();
 	}
 
 	/**
-	 * Sets the start offset of the result set to offset. Returns $this to
-	 * allow for chaining (fluid interface).
-	 *
-	 * @param integer $offset
-	 * @return \TYPO3\Flow\Persistence\QueryInterface
-	 * @throws \InvalidArgumentException
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function setOffset($offset) {
 		if ($offset < 1 || !is_int($offset)) {
@@ -99,247 +71,136 @@ class ElasticSearchQuery implements QueryInterface {
 	}
 
 	/**
-	 * Returns the start offset of the result set.
-	 *
-	 * @return integer
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function getOffset() {
 		return $this->queryBuilder->getFrom();
 	}
 
 	/**
-	 * Returns the type this query cares for.
-	 *
-	 * @return string
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function getType() {
 		return 'TYPO3\TYPO3CR\Domain\Model\NodeInterface';
 	}
 
 	/**
-	 * Sets the property names to order the result by. Expected like this:
-	 * array(
-	 *  'foo' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_ASCENDING,
-	 *  'bar' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_DESCENDING
-	 * )
-	 *
-	 * @param array $orderings The property names to order by
-	 * @return \TYPO3\Flow\Persistence\QueryInterface
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function setOrderings(array $orderings) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749035);
 	}
 
 	/**
-	 * Gets the property names to order the result by, like this:
-	 * array(
-	 *  'foo' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_ASCENDING,
-	 *  'bar' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_DESCENDING
-	 * )
-	 *
-	 * @return array
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function getOrderings() {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749036);
 	}
 
 	/**
-	 * The constraint used to limit the result set. Returns $this to allow
-	 * for chaining (fluid interface).
-	 *
-	 * @param object $constraint Some constraint, depending on the backend
-	 * @return \TYPO3\Flow\Persistence\QueryInterface
-	 * @throws
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function matching($constraint) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749037);
 	}
 
 	/**
-	 * Gets the constraint for this query.
-	 *
-	 * @return mixed the constraint, or null if none
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function getConstraint() {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749038);
 	}
 
 	/**
-	 * Performs a logical conjunction of the two given constraints. The method
-	 * takes one or more constraints and concatenates them with a boolean AND.
-	 * It also accepts a single array of constraints to be concatenated.
-	 *
-	 * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function logicalAnd($constraint1) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749039);
 	}
 
 	/**
-	 * Performs a logical disjunction of the two given constraints. The method
-	 * takes one or more constraints and concatenates them with a boolean OR.
-	 * It also accepts a single array of constraints to be concatenated.
-	 *
-	 * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function logicalOr($constraint1) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749040);
 	}
 
 	/**
-	 * Performs a logical negation of the given constraint
-	 *
-	 * @param object $constraint Constraint to negate
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function logicalNot($constraint) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749041);
 	}
 
 	/**
-	 * Returns an equals criterion used for matching objects against a query.
-	 *
-	 * It matches if the $operand equals the value of the property named
-	 * $propertyName. If $operand is NULL a strict check for NULL is done. For
-	 * strings the comparison can be done with or without case-sensitivity.
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param mixed $operand The value to compare with
-	 * @param boolean $caseSensitive Whether the equality test should be done case-sensitive for strings
-	 * @return object
-	 * @todo Decide what to do about equality on multi-valued properties
-	 * @throws \TYPO3\Flow\Exception
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function equals($propertyName, $operand, $caseSensitive = TRUE) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749042);
 	}
 
 	/**
-	 * Returns a like criterion used for matching objects against a query.
-	 * Matches if the property named $propertyName is like the $operand, using
-	 * standard SQL wildcards.
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param string $operand The value to compare with
-	 * @param boolean $caseSensitive Whether the matching should be done case-sensitive
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a non-string property
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function like($propertyName, $operand, $caseSensitive = TRUE) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749043);
 	}
 
 	/**
-	 * Returns a "contains" criterion used for matching objects against a query.
-	 * It matches if the multivalued property contains the given operand.
-	 *
-	 * If NULL is given as $operand, there will never be a match!
-	 *
-	 * @param string $propertyName The name of the multivalued property to compare against
-	 * @param mixed $operand The value to compare with
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a single-valued property
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function contains($propertyName, $operand) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749044);
 	}
 
 	/**
-	 * Returns an "isEmpty" criterion used for matching objects against a query.
-	 * It matches if the multivalued property contains no values or is NULL.
-	 *
-	 * @param string $propertyName The name of the multivalued property to compare against
-	 * @return boolean
-	 * @throws \TYPO3\Flow\Exception if used on a single-valued property
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function isEmpty($propertyName) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749045);
 	}
 
 	/**
-	 * Returns an "in" criterion used for matching objects against a query. It
-	 * matches if the property's value is contained in the multivalued operand.
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param mixed $operand The value to compare with, multivalued
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function in($propertyName, $operand) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749046);
 	}
 
 	/**
-	 * Returns a less than criterion used for matching objects against a query
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param mixed $operand The value to compare with
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function lessThan($propertyName, $operand) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749047);
 	}
 
 	/**
-	 * Returns a less or equal than criterion used for matching objects against a query
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param mixed $operand The value to compare with
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function lessThanOrEqual($propertyName, $operand) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749048);
 	}
 
 	/**
-	 * Returns a greater than criterion used for matching objects against a query
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param mixed $operand The value to compare with
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function greaterThan($propertyName, $operand) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749049);
 	}
 
 	/**
-	 * Returns a greater than or equal criterion used for matching objects against a query
-	 *
-	 * @param string $propertyName The name of the property to compare against
-	 * @param mixed $operand The value to compare with
-	 * @return object
-	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function greaterThanOrEqual($propertyName, $operand) {
-		throw new Exception('Not implemented: '. __FUNCTION__);
+		throw new Exception(__FUNCTION__ . ' not implemented', 1421749050);
 	}
+
+	/**
+	 * @return ElasticSearchQueryBuilder
+	 */
+	public function getQueryBuilder() {
+		return $this->queryBuilder;
+	}
+
 }

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQuery.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQuery.php
@@ -1,0 +1,345 @@
+<?php
+/***************************************************************
+ *  (c) 2014 networkteam GmbH - all rights reserved
+ ***************************************************************/
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel;
+
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception;
+use TYPO3\Flow\Persistence\QueryInterface;
+
+class ElasticSearchQuery implements QueryInterface {
+
+	/**
+	 * @var ElasticSearchQueryBuilder
+	 */
+	protected $queryBuilder;
+
+	public function __construct(ElasticSearchQueryBuilder $elasticSearchQueryBuilder) {
+		$this->queryBuilder = $elasticSearchQueryBuilder;
+	}
+
+	/**
+	 * @param mixed $queryBuilder
+	 */
+	public function setQueryBuilder(ElasticSearchQueryBuilder $queryBuilder) {
+		$this->queryBuilder = $queryBuilder;
+	}
+
+	/**
+	 * @return ElasticSearchQueryBuilder
+	 */
+	public function getQueryBuilder() {
+		return $this->queryBuilder;
+	}
+
+	/**
+	 * Executes the query and returns the result.
+	 *
+	 * @param bool $cacheResult If the result cache should be used
+	 * @return \TYPO3\Flow\Persistence\QueryResultInterface The query result
+	 * @api
+	 */
+	public function execute($cacheResult = FALSE) {
+		return new ElasticSearchQueryResult($this);
+	}
+
+	/**
+	 * Returns the query result count.
+	 *
+	 * @return integer The query result count
+	 * @api
+	 */
+	public function count() {
+		return $this->queryBuilder->getTotalItems();
+	}
+
+	/**
+	 * Sets the maximum size of the result set to limit. Returns $this to allow
+	 * for chaining (fluid interface).
+	 *
+	 * @param integer $limit
+	 * @return \TYPO3\Flow\Persistence\QueryInterface
+	 * @throws \InvalidArgumentException
+	 * @api
+	 */
+	public function setLimit($limit) {
+		if ($limit < 1 || !is_int($limit)) {
+			throw new \InvalidArgumentException('Expecting integer greater than zero for limit');
+		}
+
+		$this->queryBuilder->limit($limit);
+	}
+
+	/**
+	 * Returns the maximum size of the result set to limit.
+	 *
+	 * @return integer
+	 * @api
+	 */
+	public function getLimit() {
+		return $this->queryBuilder->getLimit();
+	}
+
+	/**
+	 * Sets the start offset of the result set to offset. Returns $this to
+	 * allow for chaining (fluid interface).
+	 *
+	 * @param integer $offset
+	 * @return \TYPO3\Flow\Persistence\QueryInterface
+	 * @throws \InvalidArgumentException
+	 * @api
+	 */
+	public function setOffset($offset) {
+		if ($offset < 1 || !is_int($offset)) {
+			throw new \InvalidArgumentException('Expecting integer greater than zero for offset');
+		}
+
+		$this->queryBuilder->from($offset);
+	}
+
+	/**
+	 * Returns the start offset of the result set.
+	 *
+	 * @return integer
+	 * @api
+	 */
+	public function getOffset() {
+		return $this->queryBuilder->getFrom();
+	}
+
+	/**
+	 * Returns the type this query cares for.
+	 *
+	 * @return string
+	 * @api
+	 */
+	public function getType() {
+		return 'TYPO3\TYPO3CR\Domain\Model\NodeInterface';
+	}
+
+	/**
+	 * Sets the property names to order the result by. Expected like this:
+	 * array(
+	 *  'foo' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_ASCENDING,
+	 *  'bar' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_DESCENDING
+	 * )
+	 *
+	 * @param array $orderings The property names to order by
+	 * @return \TYPO3\Flow\Persistence\QueryInterface
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function setOrderings(array $orderings) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Gets the property names to order the result by, like this:
+	 * array(
+	 *  'foo' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_ASCENDING,
+	 *  'bar' => \TYPO3\Flow\Persistence\QueryInterface::ORDER_DESCENDING
+	 * )
+	 *
+	 * @return array
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function getOrderings() {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * The constraint used to limit the result set. Returns $this to allow
+	 * for chaining (fluid interface).
+	 *
+	 * @param object $constraint Some constraint, depending on the backend
+	 * @return \TYPO3\Flow\Persistence\QueryInterface
+	 * @throws
+	 * @api
+	 */
+	public function matching($constraint) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Gets the constraint for this query.
+	 *
+	 * @return mixed the constraint, or null if none
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function getConstraint() {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Performs a logical conjunction of the two given constraints. The method
+	 * takes one or more constraints and concatenates them with a boolean AND.
+	 * It also accepts a single array of constraints to be concatenated.
+	 *
+	 * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function logicalAnd($constraint1) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Performs a logical disjunction of the two given constraints. The method
+	 * takes one or more constraints and concatenates them with a boolean OR.
+	 * It also accepts a single array of constraints to be concatenated.
+	 *
+	 * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function logicalOr($constraint1) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Performs a logical negation of the given constraint
+	 *
+	 * @param object $constraint Constraint to negate
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function logicalNot($constraint) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns an equals criterion used for matching objects against a query.
+	 *
+	 * It matches if the $operand equals the value of the property named
+	 * $propertyName. If $operand is NULL a strict check for NULL is done. For
+	 * strings the comparison can be done with or without case-sensitivity.
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param mixed $operand The value to compare with
+	 * @param boolean $caseSensitive Whether the equality test should be done case-sensitive for strings
+	 * @return object
+	 * @todo Decide what to do about equality on multi-valued properties
+	 * @throws \TYPO3\Flow\Exception
+	 * @api
+	 */
+	public function equals($propertyName, $operand, $caseSensitive = TRUE) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns a like criterion used for matching objects against a query.
+	 * Matches if the property named $propertyName is like the $operand, using
+	 * standard SQL wildcards.
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param string $operand The value to compare with
+	 * @param boolean $caseSensitive Whether the matching should be done case-sensitive
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a non-string property
+	 * @api
+	 */
+	public function like($propertyName, $operand, $caseSensitive = TRUE) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns a "contains" criterion used for matching objects against a query.
+	 * It matches if the multivalued property contains the given operand.
+	 *
+	 * If NULL is given as $operand, there will never be a match!
+	 *
+	 * @param string $propertyName The name of the multivalued property to compare against
+	 * @param mixed $operand The value to compare with
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a single-valued property
+	 * @api
+	 */
+	public function contains($propertyName, $operand) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns an "isEmpty" criterion used for matching objects against a query.
+	 * It matches if the multivalued property contains no values or is NULL.
+	 *
+	 * @param string $propertyName The name of the multivalued property to compare against
+	 * @return boolean
+	 * @throws \TYPO3\Flow\Exception if used on a single-valued property
+	 * @api
+	 */
+	public function isEmpty($propertyName) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns an "in" criterion used for matching objects against a query. It
+	 * matches if the property's value is contained in the multivalued operand.
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param mixed $operand The value to compare with, multivalued
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property
+	 * @api
+	 */
+	public function in($propertyName, $operand) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns a less than criterion used for matching objects against a query
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param mixed $operand The value to compare with
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
+	 * @api
+	 */
+	public function lessThan($propertyName, $operand) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns a less or equal than criterion used for matching objects against a query
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param mixed $operand The value to compare with
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
+	 * @api
+	 */
+	public function lessThanOrEqual($propertyName, $operand) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns a greater than criterion used for matching objects against a query
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param mixed $operand The value to compare with
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
+	 * @api
+	 */
+	public function greaterThan($propertyName, $operand) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+
+	/**
+	 * Returns a greater than or equal criterion used for matching objects against a query
+	 *
+	 * @param string $propertyName The name of the property to compare against
+	 * @param mixed $operand The value to compare with
+	 * @return object
+	 * @throws \TYPO3\Flow\Exception if used on a multi-valued property or with a non-literal/non-DateTime operand
+	 * @api
+	 */
+	public function greaterThanOrEqual($propertyName, $operand) {
+		throw new Exception('Not implemented: '. __FUNCTION__);
+	}
+}

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -1,7 +1,6 @@
 <?php
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel;
 
-
 /*                                                                                                  *
  * This script belongs to the TYPO3 Flow package "Flowpack.ElasticSearch.ContentRepositoryAdaptor". *
  *                                                                                                  *
@@ -135,13 +134,6 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	/**
 	 * HIGH-LEVEL API
 	 */
-
-	/**
-	 * @return \TYPO3\TYPO3CR\Domain\Model\NodeType
-	 */
-	public function getNodeType() {
-		return $this->contextNode->getNodeType();
-	}
 
 	/**
 	 * Filter by node type, taking inheritance into account.
@@ -380,14 +372,14 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
-	 * @return int
+	 * @return integer
 	 */
 	public function getLimit() {
 		return $this->limit;
 	}
 
 	/**
-	 * @return int
+	 * @return integer
 	 */
 	public function getFrom() {
 		return $this->from;
@@ -457,6 +449,8 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
+	 * Get a query result object for lazy execution of the query
+	 *
 	 * @return array|\TYPO3\Flow\Persistence\QueryResultInterface
 	 */
 	public function execute() {

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -63,6 +63,13 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	protected $from;
 
 	/**
+	 * Amount of total items in response without limit
+	 *
+	 * @var integer
+	 */
+	protected $totalItems;
+
+	/**
 	 * The ElasticSearch request, as it is being built up.
 	 * @var array
 	 */
@@ -121,6 +128,13 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	/**
 	 * HIGH-LEVEL API
 	 */
+
+	/**
+	 * @return \TYPO3\TYPO3CR\Domain\Model\NodeType
+	 */
+	public function getNodeType() {
+		return $this->contextNode->getNodeType();
+	}
 
 	/**
 	 * Filter by node type, taking inheritance into account.
@@ -196,7 +210,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		$currentWorkspaceNestingLevel = 1;
 		$workspace = $this->contextNode->getContext()->getWorkspace();
 		while ($workspace->getBaseWorkspace() !== NULL) {
-			$currentWorkspaceNestingLevel ++;
+			$currentWorkspaceNestingLevel++;
 			$workspace = $workspace->getBaseWorkspace();
 		}
 
@@ -307,11 +321,32 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
+	 * @return integer
+	 */
+	public function getTotalItems() {
+		return $this->totalItems;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLimit() {
+		return $this->limit;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getFrom() {
+		return $this->from;
+	}
+
+	/**
 	 * Execute the query and return the list of nodes as result
 	 *
 	 * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>
 	 */
-	public function execute() {
+	public function fetch() {
 		$timeBefore = microtime(TRUE);
 		$response = $this->elasticSearchClient->getIndex()->request('GET', '/_search', array(), json_encode($this->request));
 		$timeAfterwards = microtime(TRUE);
@@ -320,8 +355,10 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		$hits = $treatedContent['hits'];
 
 		if ($this->logThisQuery === TRUE) {
-			$this->logger->log('Query Log (' . $this->logMessage . '): ' . json_encode($this->request) . ' -- execution time: ' . (($timeAfterwards-$timeBefore)*1000) . ' ms -- Limit: ' . $this->limit . ' -- Number of results returned: ' . count($hits['hits']) . ' -- Total Results: ' . $hits['total'], LOG_DEBUG);
+			$this->logger->log('Query Log (' . $this->logMessage . '): ' . json_encode($this->request) . ' -- execution time: ' . (($timeAfterwards - $timeBefore) * 1000) . ' ms -- Limit: ' . $this->limit . ' -- Number of results returned: ' . count($hits['hits']) . ' -- Total Results: ' . $hits['total'], LOG_DEBUG);
 		}
+
+		$this->totalItems = $hits['total'];
 
 		if ($hits['total'] === 0) {
 			return array();
@@ -368,6 +405,15 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
+	 * @return array|\TYPO3\Flow\Persistence\QueryResultInterface
+	 */
+	public function execute() {
+		$elasticSerachQuery = new ElasticSearchQuery($this);
+		$result = $elasticSerachQuery->execute();
+		return $result;
+	}
+
+	/**
 	 * Return the total number of hits for the query.
 	 *
 	 * @return integer
@@ -381,7 +427,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		$count = $treatedContent['count'];
 
 		if ($this->logThisQuery === TRUE) {
-			$this->logger->log('Query Log (' . $this->logMessage . '): ' . json_encode($this->request) . ' -- execution time: ' . (($timeAfterwards-$timeBefore)*1000) . ' ms -- Total Results: ' . $count, LOG_DEBUG);
+			$this->logger->log('Query Log (' . $this->logMessage . '): ' . json_encode($this->request) . ' -- execution time: ' . (($timeAfterwards - $timeBefore) * 1000) . ' ms -- Total Results: ' . $count, LOG_DEBUG);
 		}
 
 		return $count;

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -1,0 +1,221 @@
+<?php
+/***************************************************************
+ *  (c) 2014 networkteam GmbH - all rights reserved
+ ***************************************************************/
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel;
+
+
+use TYPO3\Flow\Persistence\QueryResultInterface;
+
+class ElasticSearchQueryResult implements QueryResultInterface {
+
+	/**
+	 * @var ElasticSearchQuery
+	 */
+	protected $elasticSearchQuery;
+
+	/**
+	 * @var array
+	 */
+	protected $results = NULL;
+
+	/**
+	 * @var integer
+	 */
+	protected $count = NULL;
+
+	public function __construct(ElasticSearchQuery $elasticSearchQuery) {
+		$this->elasticSearchQuery = $elasticSearchQuery;
+	}
+
+	protected function initialize() {
+		if ($this->results === NULL) {
+			$this->results = $this->elasticSearchQuery->getQueryBuilder()->fetch();
+		}
+	}
+
+	/**
+	 * @param \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQuery $query
+	 */
+	public function setQuery(ElasticSearchQuery $query) {
+		$this->elasticSearchQuery = $query;
+		$this->results = NULL;
+	}
+
+	/**
+	 * @return \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQuery
+	 */
+	public function getQuery() {
+		return clone $this->elasticSearchQuery;
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Return the current element
+	 *
+	 * @link http://php.net/manual/en/iterator.current.php
+	 * @return mixed Can return any type.
+	 */
+	public function current() {
+		$this->initialize();
+		return current($this->results);
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Move forward to next element
+	 *
+	 * @link http://php.net/manual/en/iterator.next.php
+	 * @return void Any returned value is ignored.
+	 */
+	public function next() {
+		$this->initialize();
+		return next($this->results);
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Return the key of the current element
+	 *
+	 * @link http://php.net/manual/en/iterator.key.php
+	 * @return mixed scalar on success, or null on failure.
+	 */
+	public function key() {
+		$this->initialize();
+		return key($this->results);
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Checks if current position is valid
+	 *
+	 * @link http://php.net/manual/en/iterator.valid.php
+	 * @return boolean The return value will be casted to boolean and then evaluated.
+	 * Returns true on success or false on failure.
+	 */
+	public function valid() {
+		$this->initialize();
+		return current($this->results) !== FALSE;
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Rewind the Iterator to the first element
+	 *
+	 * @link http://php.net/manual/en/iterator.rewind.php
+	 * @return void Any returned value is ignored.
+	 */
+	public function rewind() {
+		$this->initialize();
+		reset($this->results);
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Whether a offset exists
+	 *
+	 * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+	 * @param mixed $offset <p>
+	 * An offset to check for.
+	 * </p>
+	 * @return boolean true on success or false on failure.
+	 * </p>
+	 * <p>
+	 * The return value will be casted to boolean if non-boolean was returned.
+	 */
+	public function offsetExists($offset) {
+		$this->initialize();
+		return isset($this->results[$offset]);
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Offset to retrieve
+	 *
+	 * @link http://php.net/manual/en/arrayaccess.offsetget.php
+	 * @param mixed $offset <p>
+	 * The offset to retrieve.
+	 * </p>
+	 * @return mixed Can return all value types.
+	 */
+	public function offsetGet($offset) {
+		$this->initialize();
+		return $this->results[$offset];
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Offset to set
+	 *
+	 * @link http://php.net/manual/en/arrayaccess.offsetset.php
+	 * @param mixed $offset <p>
+	 * The offset to assign the value to.
+	 * </p>
+	 * @param mixed $value <p>
+	 * The value to set.
+	 * </p>
+	 * @return void
+	 */
+	public function offsetSet($offset, $value) {
+		$this->initialize();
+		$this->results[$offset] = $value;
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * Offset to unset
+	 *
+	 * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+	 * @param mixed $offset <p>
+	 * The offset to unset.
+	 * </p>
+	 * @return void
+	 */
+	public function offsetUnset($offset) {
+		$this->initialize();
+		unset($this->results[$offset]);
+	}
+
+	/**
+	 * Returns the first object in the result set
+	 *
+	 * @return object
+	 * @api
+	 */
+	public function getFirst() {
+		$this->initialize();
+		if (count($this->results) > 0) {
+			return array_slice($this->results, 0, 1);
+		}
+	}
+
+	/**
+	 * Returns an array with the objects in the result set
+	 *
+	 * @return array
+	 * @api
+	 */
+	public function toArray() {
+		$this->initialize();
+		return $this->results;
+	}
+
+	/**
+	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * Count elements of an object
+	 *
+	 * @link http://php.net/manual/en/countable.count.php
+	 * @return int The custom count as an integer.
+	 * </p>
+	 * <p>
+	 * The return value is cast to an integer.
+	 */
+	public function count() {
+		if ($this->count === NULL) {
+			$this->count = $this->elasticSearchQuery->getQueryBuilder()->count();
+		}
+
+		return $this->count;
+	}
+}

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -1,10 +1,15 @@
 <?php
-/***************************************************************
- *  (c) 2014 networkteam GmbH - all rights reserved
- ***************************************************************/
-
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel;
 
+/*                                                                                                  *
+ * This script belongs to the TYPO3 Flow package "Flowpack.ElasticSearch.ContentRepositoryAdaptor". *
+ *                                                                                                  *
+ * It is free software; you can redistribute it and/or modify it under                              *
+ * the terms of the GNU Lesser General Public License, either version 3                             *
+ *  of the License, or (at your option) any later version.                                          *
+ *                                                                                                  *
+ * The TYPO3 project - inspiring people to share!                                                   *
+ *                                                                                                  */
 
 use TYPO3\Flow\Persistence\QueryResultInterface;
 
@@ -29,18 +34,15 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 		$this->elasticSearchQuery = $elasticSearchQuery;
 	}
 
+	/**
+	 * Initialize the results by really executing the query
+	 */
 	protected function initialize() {
 		if ($this->results === NULL) {
-			$this->results = $this->elasticSearchQuery->getQueryBuilder()->fetch();
+			$queryBuilder = $this->elasticSearchQuery->getQueryBuilder();
+			$this->results = $queryBuilder->fetch();
+			$this->count = $queryBuilder->getTotalItems();
 		}
-	}
-
-	/**
-	 * @param \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQuery $query
-	 */
-	public function setQuery(ElasticSearchQuery $query) {
-		$this->elasticSearchQuery = $query;
-		$this->results = NULL;
 	}
 
 	/**
@@ -51,11 +53,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Return the current element
-	 *
-	 * @link http://php.net/manual/en/iterator.current.php
-	 * @return mixed Can return any type.
+	 * {@inheritdoc}
 	 */
 	public function current() {
 		$this->initialize();
@@ -63,11 +61,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Move forward to next element
-	 *
-	 * @link http://php.net/manual/en/iterator.next.php
-	 * @return void Any returned value is ignored.
+	 * {@inheritdoc}
 	 */
 	public function next() {
 		$this->initialize();
@@ -75,11 +69,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Return the key of the current element
-	 *
-	 * @link http://php.net/manual/en/iterator.key.php
-	 * @return mixed scalar on success, or null on failure.
+	 * {@inheritdoc}
 	 */
 	public function key() {
 		$this->initialize();
@@ -87,12 +77,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Checks if current position is valid
-	 *
-	 * @link http://php.net/manual/en/iterator.valid.php
-	 * @return boolean The return value will be casted to boolean and then evaluated.
-	 * Returns true on success or false on failure.
+	 * {@inheritdoc}
 	 */
 	public function valid() {
 		$this->initialize();
@@ -100,11 +85,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Rewind the Iterator to the first element
-	 *
-	 * @link http://php.net/manual/en/iterator.rewind.php
-	 * @return void Any returned value is ignored.
+	 * {@inheritdoc}
 	 */
 	public function rewind() {
 		$this->initialize();
@@ -112,17 +93,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Whether a offset exists
-	 *
-	 * @link http://php.net/manual/en/arrayaccess.offsetexists.php
-	 * @param mixed $offset <p>
-	 * An offset to check for.
-	 * </p>
-	 * @return boolean true on success or false on failure.
-	 * </p>
-	 * <p>
-	 * The return value will be casted to boolean if non-boolean was returned.
+	 * {@inheritdoc}
 	 */
 	public function offsetExists($offset) {
 		$this->initialize();
@@ -130,14 +101,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Offset to retrieve
-	 *
-	 * @link http://php.net/manual/en/arrayaccess.offsetget.php
-	 * @param mixed $offset <p>
-	 * The offset to retrieve.
-	 * </p>
-	 * @return mixed Can return all value types.
+	 * {@inheritdoc}
 	 */
 	public function offsetGet($offset) {
 		$this->initialize();
@@ -145,17 +109,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Offset to set
-	 *
-	 * @link http://php.net/manual/en/arrayaccess.offsetset.php
-	 * @param mixed $offset <p>
-	 * The offset to assign the value to.
-	 * </p>
-	 * @param mixed $value <p>
-	 * The value to set.
-	 * </p>
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function offsetSet($offset, $value) {
 		$this->initialize();
@@ -163,14 +117,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
-	 * Offset to unset
-	 *
-	 * @link http://php.net/manual/en/arrayaccess.offsetunset.php
-	 * @param mixed $offset <p>
-	 * The offset to unset.
-	 * </p>
-	 * @return void
+	 * {@inheritdoc}
 	 */
 	public function offsetUnset($offset) {
 		$this->initialize();
@@ -178,10 +125,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * Returns the first object in the result set
-	 *
-	 * @return object
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function getFirst() {
 		$this->initialize();
@@ -191,10 +135,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * Returns an array with the objects in the result set
-	 *
-	 * @return array
-	 * @api
+	 * {@inheritdoc}
 	 */
 	public function toArray() {
 		$this->initialize();
@@ -202,14 +143,7 @@ class ElasticSearchQueryResult implements QueryResultInterface {
 	}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
-	 * Count elements of an object
-	 *
-	 * @link http://php.net/manual/en/countable.count.php
-	 * @return int The custom count as an integer.
-	 * </p>
-	 * <p>
-	 * The return value is cast to an integer.
+	 * {@inheritdoc}
 	 */
 	public function count() {
 		if ($this->count === NULL) {


### PR DESCRIPTION
This change introduces a `ElasticsearchQueryResult` object that implements `QueryResultInterface` and can be used by the default `<f:widget.paginate>` view helper.

The result objects allows to integrate metadata in a compatible way without introducing nested arrays (e.g. `results.nodes`).