### PR TITLE
[BUGFIX] Correctly filter for dimension combinations in query

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -626,6 +626,11 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html
 		$this->queryFilter('terms', array('__workspace' => array_unique(array('live', $contextNode->getContext()->getWorkspace()->getName()))));
 
+		// match exact dimension values for each dimension, this works because the indexing flattens the node variants for all dimension preset combinations
+		foreach ($contextNode->getContext()->getDimensions() as $dimensionName => $dimensionValues) {
+			$this->queryFilter('terms', array('__dimensionCombinations.' . $dimensionName => $dimensionValues, 'execution' => 'and'));
+		}
+
 		$this->contextNode = $contextNode;
 
 		return $this;


### PR DESCRIPTION
This change adds a terms filter to the query method that includes the
context dimension values to fetch only matching documents. This works
for most dimension usages except complex use-cases with overlapping
fallback chains.

The result count should now be correct when querying nodes with multiple
variants, so it solves at least one problem of #44.