### PR TITLE
[TASK] Fix Unittests

### DIFF
--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -27,6 +27,7 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 		$node = $this->getMock('TYPO3\TYPO3CR\Domain\Model\NodeInterface');
 		$node->expects($this->any())->method('getPath')->will($this->returnValue('/foo/bar'));
 		$mockContext = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Service\Context')->disableOriginalConstructor()->getMock();
+		$mockContext->expects($this->any())->method('getDimensions')->will($this->returnValue(array()));
 		$node->expects($this->any())->method('getContext')->will($this->returnValue($mockContext));
 
 		$mockWorkspace = $this->getMockBuilder('TYPO3\TYPO3CR\Domain\Model\Workspace')->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
Extend the $mockContext with an method getDimensions that returns an empty array to fix the current tests