### PR TITLE
[TASK] Add aggregation functionality

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -436,7 +436,8 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	 *
 	 * aggregationDefinition = TYPO3.TypoScript:RawArray {
 	 *   terms = TYPO3.TypoScript:RawArray {
-	 *   field = "color"
+	 *     field = "color"
+	 *   }
 	 * }
 	 *
 	 * nodes = ${Search....aggregation("color", this.aggregationDefinition).execute()}
@@ -475,7 +476,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	 * @return $this
 	 * @throws QueryBuildingException
 	 */
-	public function addSubAggregation($parentPath, $name, $aggregationConfiguration) {
+	protected function addSubAggregation($parentPath, $name, $aggregationConfiguration) {
 		// Find the parentPath
 		$path =& $this->request['aggregations'];
 

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -373,7 +373,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	/**
 	 * Add multiple filters to query.filtered.filter
 	 *
-	 * Example Usage::
+	 * Example Usage:
 	 *
 	 *   searchFilter = TYPO3.TypoScript:RawArray {
 	 *      author = 'Max'
@@ -407,6 +407,11 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	 * This method adds a field based aggregation configuration. This can be used for simple
 	 * aggregations like terms
 	 *
+	 * Example Usage to create a terms aggregation for a property color:
+	 * nodes = ${Search....fieldBasedAggregation("colors", "color").execute()}
+	 *
+	 * Access all aggregation data with {nodes.aggregations} in your fluid template
+	 *
 	 * @param $name
 	 * @param $field
 	 * @param string $type
@@ -425,6 +430,19 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
+	 * This method is used to create any kind of aggregation.
+	 *
+	 * Example Usage to create a terms aggregation for a property color:
+	 *
+	 * aggregationDefinition = TYPO3.TypoScript:RawArray {
+	 *   terms = TYPO3.TypoScript:RawArray {
+	 *   field = "color"
+	 * }
+	 *
+	 * nodes = ${Search....aggregation("color", this.aggregationDefinition).execute()}
+	 *
+	 * Access all aggregation data with {nodes.aggregations} in your fluid template
+	 * 
 	 * @param string $name
 	 * @param array $aggregationDefinition
 	 * @param null $parentPath

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -404,7 +404,8 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	}
 
 	/**
-	 * Adds a simple aggregation with only filed set as configuration
+	 * This method adds a field based aggregation configuration. This can be used for simple
+	 * aggregations like terms
 	 *
 	 * @param $name
 	 * @param $field
@@ -412,21 +413,33 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	 * @param null $parentPath
 	 * @return $this
 	 */
-	public function addSimpleAggregation($name, $field, $type = 'terms', $parentPath = NULL) {
-		if(!array_key_exists("aggregations", $this->request)) {
-			$this->request['aggregations'] = array();
-		}
-
-		$aggregation = array (
-			$type => array (
+	public function fieldBasedAggregation($name, $field, $type = "terms", $parentPath = NULL) {
+		$aggregationDefinition = array(
+			$type => array(
 				'field' => $field
 			)
 		);
 
+		$this->aggregation($name, $aggregationDefinition, $parentPath);
+		return $this;
+	}
+
+	/**
+	 * @param string $name
+	 * @param array $aggregationDefinition
+	 * @param null $parentPath
+	 * @return $this
+	 * @throws QueryBuildingException
+	 */
+	public function aggregation($name, array $aggregationDefinition, $parentPath = NULL) {
+		if(!array_key_exists("aggregations", $this->request)) {
+			$this->request['aggregations'] = array();
+		}
+
 		if($parentPath !== NULL) {
-			$this->addSubAggregation($parentPath, $name, $aggregation);
+			$this->addSubAggregation($parentPath, $name, $aggregationDefinition);
 		} else {
-			$this->request['aggregations'][$name] = $aggregation;
+			$this->request['aggregations'][$name] = $aggregationDefinition;
 		}
 
 		return $this;

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -165,6 +165,14 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	}
 
 	/**
+	 * @return array
+	 */
+	public function getAggregations() {
+		$this->initialize();
+		return $this->elasticSearchQuery->getQueryBuilder()->getElasticSearchAggregationsFromLastRequest();
+	}
+
+	/**
 	 * Returns the ElasticSearch "hit" (e.g. the raw content being transferred back from ElasticSearch)
 	 * for the given node.
 	 *

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -228,7 +228,7 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 			)
 		);
 
-		$this->queryBuilder->addSimpleAggregation($name, $field, $type);
+		$this->queryBuilder->fieldBasedAggregation($name, $field, $type);
 		$actual = $this->queryBuilder->getRequest();
 
 		$this->assertInArray($expected, $actual);
@@ -238,9 +238,9 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 	 * @test
 	 */
 	public function anAggregationCanBeSubbedUnderAPath() {
-		$this->queryBuilder->addSimpleAggregation("foo", "bar");
-		$this->queryBuilder->addSimpleAggregation("bar", "bar", "terms", "foo");
-		$this->queryBuilder->addSimpleAggregation("baz", "bar", "terms", "foo.bar");
+		$this->queryBuilder->fieldBasedAggregation("foo", "bar");
+		$this->queryBuilder->fieldBasedAggregation("bar", "bar", "terms", "foo");
+		$this->queryBuilder->fieldBasedAggregation("baz", "bar", "terms", "foo.bar");
 
 		$expected = array(
 			"foo" => array(
@@ -267,8 +267,8 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 	 * @expectedException \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException
 	 */
 	public function ifTheParentPathDoesNotExistAnExceptionisThrown() {
-		$this->queryBuilder->addSimpleAggregation("foo", "bar");
-		$this->queryBuilder->addSimpleAggregation("bar", "bar", "terms", "doesNotExist");
+		$this->queryBuilder->fieldBasedAggregation("foo", "bar");
+		$this->queryBuilder->fieldBasedAggregation("bar", "bar", "terms", "doesNotExist");
 	}
 
 	/**
@@ -276,8 +276,26 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 	 * @expectedException \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException
 	 */
 	public function ifSubbedParentPathDoesNotExistAnExceptionisThrown() {
-		$this->queryBuilder->addSimpleAggregation("foo", "bar");
-		$this->queryBuilder->addSimpleAggregation("bar", "bar", "terms", "foo.doesNotExist");
+		$this->queryBuilder->fieldBasedAggregation("foo", "bar");
+		$this->queryBuilder->fieldBasedAggregation("bar", "bar", "terms", "foo.doesNotExist");
+	}
+
+	/**
+	 * @test
+	 */
+	public function aCustomAggregationDefinitionCanBeApplied() {
+		$expected = array(
+			"foo" => array(
+				"some" => array("field" => "bar"),
+				"custom" => array("field" => "bar"),
+				"arrays" => array("field" => "bar")
+			)
+		);
+
+		$this->queryBuilder->aggregation("foo", $expected['foo']);
+		$actual = $this->queryBuilder->getRequest();
+
+		$this->assertInArray($expected, $actual);
 	}
 
 	/**

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -175,6 +175,9 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 		$this->assertSame($expected, $actual['sort']);
 	}
 
+	/**
+	 * @return array
+	 */
 	public function rangeConstraintExamples() {
 		return array(
 			array('greaterThan', 'gt', 10),
@@ -197,6 +200,84 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase {
 		);
 		$actual = $this->queryBuilder->getRequest();
 		$this->assertInArray($expected, $actual['query']['filtered']['filter']['bool']['must']);
+	}
+
+	/**
+	 * @return array
+	 */
+	public function simpleAggregationExamples() {
+		return array(
+			array('min', 'foo', 'bar'),
+			array('terms', 'foo', 'bar'),
+			array('sum', 'foo', 'bar'),
+			array('stats', 'foo', 'bar'),
+			array('value_count', 'foo', 'bar')
+		);
+	}
+
+	/**
+	 * @test
+	 * @dataProvider simpleAggregationExamples
+	 */
+	public function anSimpleAggregationCanBeAddedToTheRequest($type, $name, $field) {
+		$expected = array(
+			$name => array(
+				$type => array(
+					'field' => $field
+				)
+			)
+		);
+
+		$this->queryBuilder->addSimpleAggregation($name, $field, $type);
+		$actual = $this->queryBuilder->getRequest();
+
+		$this->assertInArray($expected, $actual);
+	}
+
+	/**
+	 * @test
+	 */
+	public function anAggregationCanBeSubbedUnderAPath() {
+		$this->queryBuilder->addSimpleAggregation("foo", "bar");
+		$this->queryBuilder->addSimpleAggregation("bar", "bar", "terms", "foo");
+		$this->queryBuilder->addSimpleAggregation("baz", "bar", "terms", "foo.bar");
+
+		$expected = array(
+			"foo" => array(
+				"terms" => array("field" => "bar"),
+				"aggregations" => array(
+					"bar" => array(
+						"terms" => array("field" => "bar"),
+						"aggregations" => array(
+							"baz" => array(
+								"terms" => array("field" => "bar")
+							)
+						)
+					)
+				)
+			)
+		);
+
+		$actual = $this->queryBuilder->getRequest();
+		$this->assertInArray($expected, $actual);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException
+	 */
+	public function ifTheParentPathDoesNotExistAnExceptionisThrown() {
+		$this->queryBuilder->addSimpleAggregation("foo", "bar");
+		$this->queryBuilder->addSimpleAggregation("bar", "bar", "terms", "doesNotExist");
+	}
+
+	/**
+	 * @test
+	 * @expectedException \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException
+	 */
+	public function ifSubbedParentPathDoesNotExistAnExceptionisThrown() {
+		$this->queryBuilder->addSimpleAggregation("foo", "bar");
+		$this->queryBuilder->addSimpleAggregation("bar", "bar", "terms", "foo.doesNotExist");
 	}
 
 	/**


### PR DESCRIPTION
This change implements a new function addSimpleAggregation() and a new low-level function addSubAggregation to add (sub-) aggregatons to a elasticsearch request.

Usage to get aggregation for property "color" in a node Vendor.Name:NodeType:
`nodes = $Search.query(site).nodeType("Vendor.Name:NodeType").addSimpleAggregation("color", "color").execute() `
To get your aggregationResults access {nodes.aggregations} in your fluid template.

This change also allows you to add sub-aggregations:
`nodes = $Search.query(site).nodeType("Vendor.Name:NodeType").addSimpleAggregation("color", "color").addSimpleAggregation("type", "type", "terms", "color" ).execute() `