### PR TITLE
[TASK] Querybuilder refactoring

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -512,7 +512,9 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	 * @return integer
 	 */
 	public function getTotalItems() {
-		return $this->result['total'];
+		if (array_key_exists('total', $this->result)) {
+            return (int) $this->result['total'];
+        }
 	}
 
 	/**
@@ -545,7 +547,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 	/**
 	 * Execute the query and return the list of nodes as result.
 	 *
-	 * This method is rather internal; just to be called from the ElasticSearchQueryResult. For the public API, please use execute()
+     * This method is rather internal; just to be called from the ElasticSearchQueryResult. For the public API, please use execute()
 	 *
 	 * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>
 	 */
@@ -554,7 +556,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 		$response = $this->elasticSearchClient->getIndex()->request('GET', '/_search', array(), json_encode($this->request));
 		$timeAfterwards = microtime(TRUE);
 
-		$this->result =& $response->getTreatedContent();
+        $this->result = $response->getTreatedContent();
 
 		$this->result['nodes'] = array();
 		if (array_key_exists('hits', $this->result) && is_array($this->result['hits']) && count($this->result['hits']) > 0) {

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -175,7 +175,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function getAggregations() {
 		$this->initialize();
-		return $this->elasticSearchQuery->getQueryBuilder()->getElasticSearchAggregationsFromLastRequest();
+		return $this->result['aggregations'];
 	}
 
 	/**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -25,7 +25,12 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	/**
 	 * @var array
 	 */
-	protected $results = NULL;
+	protected $result = NULL;
+
+	/**
+	 * @var array
+	 */
+	protected $nodes = NULL;
 
 	/**
 	 * @var integer
@@ -40,9 +45,10 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 * Initialize the results by really executing the query
 	 */
 	protected function initialize() {
-		if ($this->results === NULL) {
+		if ($this->result === NULL) {
 			$queryBuilder = $this->elasticSearchQuery->getQueryBuilder();
-			$this->results = $queryBuilder->fetch();
+			$this->result = $queryBuilder->fetch();
+			$this->nodes = $this->result['nodes'];
 			$this->count = $queryBuilder->getTotalItems();
 		}
 	}
@@ -59,7 +65,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function current() {
 		$this->initialize();
-		return current($this->results);
+		return current($this->nodes);
 	}
 
 	/**
@@ -67,7 +73,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function next() {
 		$this->initialize();
-		return next($this->results);
+		return next($this->nodes);
 	}
 
 	/**
@@ -75,7 +81,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function key() {
 		$this->initialize();
-		return key($this->results);
+		return key($this->nodes);
 	}
 
 	/**
@@ -83,7 +89,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function valid() {
 		$this->initialize();
-		return current($this->results) !== FALSE;
+		return current($this->nodes) !== FALSE;
 	}
 
 	/**
@@ -91,7 +97,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function rewind() {
 		$this->initialize();
-		reset($this->results);
+		reset($this->nodes);
 	}
 
 	/**
@@ -99,7 +105,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function offsetExists($offset) {
 		$this->initialize();
-		return isset($this->results[$offset]);
+		return isset($this->nodes[$offset]);
 	}
 
 	/**
@@ -107,7 +113,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function offsetGet($offset) {
 		$this->initialize();
-		return $this->results[$offset];
+		return $this->nodes[$offset];
 	}
 
 	/**
@@ -115,7 +121,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function offsetSet($offset, $value) {
 		$this->initialize();
-		$this->results[$offset] = $value;
+		$this->nodes[$offset] = $value;
 	}
 
 	/**
@@ -123,7 +129,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function offsetUnset($offset) {
 		$this->initialize();
-		unset($this->results[$offset]);
+		unset($this->nodes[$offset]);
 	}
 
 	/**
@@ -131,8 +137,8 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function getFirst() {
 		$this->initialize();
-		if (count($this->results) > 0) {
-			return array_slice($this->results, 0, 1);
+		if (count($this->nodes) > 0) {
+			return array_slice($this->nodes, 0, 1);
 		}
 	}
 
@@ -141,7 +147,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function toArray() {
 		$this->initialize();
-		return $this->results;
+		return $this->nodes;
 	}
 
 	/**
@@ -161,7 +167,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
 	 */
 	public function getAccessibleCount() {
 		$this->initialize();
-		return count($this->results);
+		return count($this->nodes);
 	}
 
 	/**

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -1,0 +1,9 @@
+TYPO3:
+  TYPO3CR:
+    Search:
+      elasticSearch:
+        indexName: typo3cr_testing
+        log:
+          backendOptions:
+            fileBackend:
+              logFileURL: '%FLOW_PATH_DATA%Logs/ElasticSearch_Testing.log'

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -103,11 +103,12 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     public function filterLimitQuery()
     {
         $resultCount = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->count();
-        $this->assertEquals(6, $resultCount, 'Asserting the count query returns the total count.');
+        $this->assertEquals(3, $resultCount, 'Asserting the count query returns the total count.');
 
         $result = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->execute();
-        $this->assertCount(1, $result, 'Asserting the executed query returns a valid number of items.');
+
         $this->assertEquals(1, $result->getAccessibleCount(), 'Asserting that getAccessibleCount returns the correct number');
+        $this->assertCount(1, $result->toArray(), 'Asserting the executed query returns a valid number of items.');
     }
 
 

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -102,13 +102,15 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function filterLimitQuery()
     {
+        $resultCount = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->count();
+        $this->assertEquals(6, $resultCount, 'Asserting the count query returns the total count.');
+
         $result = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->execute();
         $this->assertCount(1, $result, 'Asserting the executed query returns a valid number of items.');
-
-        $resultCount = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->count();
-        $this->assertEquals(1, $resultCount, 'Asserting the count query returns a valid count.');
+        $this->assertEquals(1, $result->getAccessibleCount(), 'Asserting that getAccessibleCount returns the correct number');
     }
-    
+
+
     protected function createNodesForNodeSearchTest() {
         $rootNode = $this->context->getRootNode();
 

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -1,0 +1,126 @@
+<?php
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Eel;
+
+/*                                                                                                  *
+ * This script belongs to the TYPO3 Flow package "Flowpack.ElasticSearch.ContentRepositoryAdaptor". *
+ *                                                                                                  *
+ * It is free software; you can redistribute it and/or modify it under                              *
+ * the terms of the GNU Lesser General Public License, either version 3                             *
+ *  of the License, or (at your option) any later version.                                          *
+ *                                                                                                  *
+ * The TYPO3 project - inspiring people to share!                                                   *
+ *                                                                                                  */
+
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQuery;
+
+/**
+ * Testcase for ElasticSearchQuery
+ */
+class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
+{
+
+    /**
+     * @var \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController
+     */
+    protected $nodeIndexCommandController;
+
+    /**
+     * @var \TYPO3\TYPO3CR\Domain\Service\Context
+     */
+    protected $context;
+
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var \TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface
+     */
+    protected $contextFactory;
+
+    /**
+     * @var \TYPO3\TYPO3CR\Domain\Service\NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var \TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    /**
+     * @var \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder
+     */
+    protected $queryBuilder;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->nodeTypeManager = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\NodeTypeManager');
+        $this->contextFactory = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\ContextFactoryInterface');
+        $this->context = $this->contextFactory->create(array('workspaceName' => 'live', 'dimensions' => array('language' => array('de'))));
+        $this->nodeDataRepository = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Repository\NodeDataRepository');
+        $this->queryBuilder = $this->objectManager->get('Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder');
+
+        $this->queryBuilder->log();
+        $this->createNodesForNodeSearchTest();
+
+        $this->nodeIndexCommandController = $this->objectManager->get('Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController');
+        $this->nodeIndexCommandController->buildCommand();
+
+    }
+
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->inject($this->contextFactory, 'contextInstances', array());
+        $this->nodeIndexCommandController->cleanupCommand();
+    }
+
+    /**
+     * @test
+     */
+    public function filterByNodeType()
+    {
+        $resultCount = $this->queryBuilder->query($this->context->getRootNode())->nodeType('TYPO3.Neos.NodeTypes:Page')->count();
+        $this->assertEquals(3, $resultCount);
+    }
+
+    /**
+     * @test
+     */
+    public function filterNodeByProperty()
+    {
+        $resultCount = $this->queryBuilder->query($this->context->getRootNode())->exactMatch('title', 'egg')->count();
+        $this->assertEquals(1, $resultCount);
+    }
+
+    /**
+     * @test
+     */
+    public function filterLimitQuery()
+    {
+        $result = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->execute();
+        $this->assertCount(1, $result, 'Asserting the executed query returns a valid number of items.');
+
+        $resultCount = $this->queryBuilder->query($this->context->getRootNode())->limit(1)->count();
+        $this->assertEquals(1, $resultCount, 'Asserting the count query returns a valid count.');
+    }
+    
+    protected function createNodesForNodeSearchTest() {
+        $rootNode = $this->context->getRootNode();
+
+        $newNode1 = $rootNode->createNode('test-node-1', $this->nodeTypeManager->getNodeType('TYPO3.Neos.NodeTypes:Page'));
+        $newNode1->setProperty('title', 'chicken');
+
+        $newNode2 = $rootNode->createNode('test-node-2', $this->nodeTypeManager->getNodeType('TYPO3.Neos.NodeTypes:Page'));
+        $newNode2->setProperty('title', 'chicken');
+
+        $newNode2 = $rootNode->createNode('test-node-3', $this->nodeTypeManager->getNodeType('TYPO3.Neos.NodeTypes:Page'));
+        $newNode2->setProperty('title', 'egg');
+
+        $this->persistenceManager->persistAll();
+    }
+}


### PR DESCRIPTION
Refactor the queryBuilder and the result object as a basis for further extensions and improvements.
ElasticSearchQueryBuilder::fetch() now returns an array including the nodes and the other meta data results. The ElasticSearchQueryResult still provides the nodes through its ArrayAccess implementation but also returns additional data like aggregations and suggestions through specific getters.

Also added a first functional test. All tests are failing right now due to existing bugs.

Jira: IN-4