### PR TITLE
[TASK] Add generic sort operation

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -171,18 +171,14 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      */
     public function sortDesc($propertyName)
     {
-        if (!isset($this->request['sort'])) {
-            $this->request['sort'] = array();
-        }
+        $configuration = [
+            $propertyName => ['order' => 'desc']
+        ];
 
-        // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-sort.html
-        $this->request['sort'][] = array(
-            $propertyName => array('order' => 'desc')
-        );
+        $this->sort($configuration);
 
         return $this;
     }
-
 
     /**
      * Sort ascending by $propertyName
@@ -193,18 +189,32 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      */
     public function sortAsc($propertyName)
     {
-        if (!isset($this->request['sort'])) {
-            $this->request['sort'] = array();
-        }
+        $configuration = [
+            $propertyName => ['order' => 'asc']
+        ];
 
-        // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-sort.html
-        $this->request['sort'][] = array(
-            $propertyName => array('order' => 'asc')
-        );
+        $this->sort($configuration);
 
         return $this;
     }
 
+    /**
+     * Add a $configuration sort filter to the request
+     *
+     * @param array $configuration
+     * @return ElasticSearchQueryBuilder
+     * @api
+     */
+    public function sort($configuration)
+    {
+        if (!isset($this->request['sort'])) {
+            $this->request['sort'] = array();
+        }
+
+        $this->request['sort'][] = $configuration;
+
+        return $this;
+    }
 
     /**
      * output only $limit records
@@ -451,7 +461,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      * nodes = ${Search....aggregation("color", this.aggregationDefinition).execute()}
      *
      * Access all aggregation data with {nodes.aggregations} in your fluid template
-     * 
+     *
      * @param string $name
      * @param array $aggregationDefinition
      * @param null $parentPath

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -192,7 +192,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
     public function getAggregations()
     {
         $this->initialize();
-        if (array_key_exists("aggregations", $this->result)) {
+        if (array_key_exists('aggregations', $this->result)) {
             return $this->result['aggregations'];
         }
         return array();
@@ -211,6 +211,23 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
     public function searchHitForNode(NodeInterface $node)
     {
         return $this->elasticSearchQuery->getQueryBuilder()->getFullElasticSearchHitForNode($node);
+    }
+
+    /**
+     * Returns the array with all sort values for a given node. The values are fetched from the raw content
+     * ElasticSearch returns within the hit data
+     *
+     * @param NodeInterface $node
+     * @return array
+     */
+    public function getSortValuesForNode(NodeInterface $node)
+    {
+        $hit = $this->searchHitForNode($node);
+        if (is_array($hit) && array_key_exists('sort', $hit)) {
+            return $hit['sort'];
+        }
+
+        return array();
     }
 
     /**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/ViewHelpers/GetHitArrayForNodeViewHelper.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/ViewHelpers/GetHitArrayForNodeViewHelper.php
@@ -1,0 +1,58 @@
+<?php
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\ViewHelpers;
+
+/*                                                                                                  *
+ * This script belongs to the TYPO3 Flow package "Flowpack.ElasticSearch.ContentRepositoryAdaptor". *
+ *                                                                                                  *
+ * It is free software; you can redistribute it and/or modify it under                              *
+ * the terms of the GNU Lesser General Public License, either version 3                             *
+ *  of the License, or (at your option) any later version.                                          *
+ *                                                                                                  *
+ * The TYPO3 project - inspiring people to share!                                                   *
+ *                                                                                                  */
+
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryResult;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * View helper to get the raw "hits" array of an ElasticSearchQueryResult for a
+ * specific node.
+ *
+ * = Examples =
+ *
+ * <code title="Basic usage">
+ * {esCrAdapter:geHitArrayForNode(queryResultObject: result, node: node)}
+ * </code>
+ * <output>
+ * array
+ * </output>
+ *
+ * You can also return specific data
+ * <code title="Fetch specific data">
+ * {esCrAdapter:geHitArrayForNode(queryResultObject: result, node: node, path: 'sort')}
+ * </code>
+ * <output>
+ * array or single value
+ * </output>
+ */
+class GetHitArrayForNodeViewHelper extends AbstractViewHelper
+{
+    /**
+     * @param ElasticSearchQueryResult $queryResultObject
+     * @param NodeInterface $node
+     * @param array|string $path
+     * @return array
+     */
+    public function render(ElasticSearchQueryResult $queryResultObject, NodeInterface $node, $path = NULL)
+    {
+        $hitArray = $queryResultObject->searchHitForNode($node);
+
+        if (!empty($path)) {
+            return \TYPO3\Flow\Utility\Arrays::getValueByPath($hitArray, $path);
+        }
+
+        return $hitArray;
+    }
+}

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -67,7 +67,7 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     {
         parent::setUp();
         $this->workspaceRepository = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Repository\WorkspaceRepository');
-        $liveWorkspace = new Workspace("live");
+        $liveWorkspace = new Workspace('live');
         $this->workspaceRepository->add($liveWorkspace);
 
         $this->nodeTypeManager = $this->objectManager->get('TYPO3\TYPO3CR\Domain\Service\NodeTypeManager');
@@ -128,8 +128,8 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function fieldBasedAggregations()
     {
-        $aggregationTitle = "titleagg";
-        $result = $this->queryBuilder->query($this->context->getRootNode())->fieldBasedAggregation($aggregationTitle, "title")->execute()->getAggregations();
+        $aggregationTitle = 'titleagg';
+        $result = $this->queryBuilder->query($this->context->getRootNode())->fieldBasedAggregation($aggregationTitle, 'title')->execute()->getAggregations();
 
         $this->assertArrayHasKey($aggregationTitle, $result);
 
@@ -148,9 +148,9 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function nodesWillBeSortedDesc()
     {
-        $descendingResult = $this->queryBuilder->query($this->context->getRootNode())->sortDesc("title")->execute();
+        $descendingResult = $this->queryBuilder->query($this->context->getRootNode())->sortDesc('title')->execute();
         $node = $descendingResult->getFirst();
-        $this->assertEquals("egg", $node->getProperty("title"), "Asserting a desc sort order by property title");
+        $this->assertEquals('egg', $node->getProperty('title'), 'Asserting a desc sort order by property title');
     }
 
     /**
@@ -158,9 +158,21 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function nodesWillBeSortedAsc()
     {
-        $ascendingResult = $this->queryBuilder->query($this->context->getRootNode())->sortAsc("title")->execute();
+        $ascendingResult = $this->queryBuilder->query($this->context->getRootNode())->sortAsc('title')->execute();
         $node = $ascendingResult->getFirst();
-        $this->assertEquals("chicken", $node->getProperty("title"), "Asserting a asc sort order by property title");
+        $this->assertEquals('chicken', $node->getProperty('title'), 'Asserting a asc sort order by property title');
+    }
+
+    /**
+     * @test
+     */
+    public function sortValuesAreReturned()
+    {
+        $result = $this->queryBuilder->query($this->context->getRootNode())->sortAsc('title')->execute();
+
+        foreach ($result as $node) {
+            $this->assertEquals(array($node->getProperty('title')), $result->getSortValuesForNode($node));
+        }
     }
 
     /**
@@ -182,7 +194,6 @@ class ElasticSearchQueryTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $dimensionContext = $this->contextFactory->create(array('workspaceName' => 'live', 'dimensions' => array('language' => array('de'))));
         $translatedNode3 = $dimensionContext->adoptNode($newNode3, TRUE);
         $translatedNode3->setProperty('title', 'Ei');
-
 
         $this->persistenceManager->persistAll();
         $this->nodeIndexCommandController->buildCommand();

--- a/Tests/Unit/ViewHelpers/GetHitArrayForNodeViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/GetHitArrayForNodeViewHelperTest.php
@@ -1,0 +1,104 @@
+<?php
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Unit\Eel;
+
+/*                                                                                                  *
+ * This script belongs to the TYPO3 Flow package "Flowpack.ElasticSearch.ContentRepositoryAdaptor". *
+ *                                                                                                  *
+ * It is free software; you can redistribute it and/or modify it under                              *
+ * the terms of the GNU Lesser General Public License, either version 3                             *
+ *  of the License, or (at your option) any later version.                                          *
+ *                                                                                                  *
+ * The TYPO3 project - inspiring people to share!                                                   *
+ *                                                                                                  */
+
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryResult;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ViewHelpers\GetHitArrayForNodeViewHelper;
+use TYPO3\TYPO3CR\Domain\Model\NodeInterface;
+
+/**
+ * Testcase for ElasticSearchQueryBuilder
+ */
+class GetHitArrayForNodeViewHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
+{
+    /**
+     * @var GetHitArrayForNodeViewHelper
+     */
+    protected $viewHelper;
+
+    public function setUp()
+    {
+        $this->viewHelper = new GetHitArrayForNodeViewHelper();
+    }
+
+    /**
+     * @test
+     */
+    public function ifNoPathIsSetTheFullHitArrayWillBeReturned()
+    {
+        $hitArray = [
+            'sort' => [
+                0 => '14'
+            ]
+        ];
+
+        $node = $this->getMock(NodeInterface::class);
+
+        $queryResult = $this->getMock(ElasticSearchQueryResult::class, array('searchHitForNode'), array(), '', false);
+        $queryResult->expects($this->once())->method('searchHitForNode')->willReturn($hitArray);
+
+        $result = $this->viewHelper->render($queryResult, $node);
+        $this->assertEquals($hitArray, $result, 'The full hit array will be returned');
+    }
+
+    /**
+     * @test
+     */
+    public function viewHelperWillReturnAPathFromHitArray()
+    {
+        $path = 'sort';
+        $hitArray = [
+            'foo'   => 'bar',
+            $path  => [
+                0 => '14',
+                1 => '18'
+            ]
+        ];
+
+        $node = $this->getMock(NodeInterface::class);
+
+        $queryResult = $this->getMock(ElasticSearchQueryResult::class, array('searchHitForNode'), array(), '', false);
+        $queryResult->expects($this->once())->method('searchHitForNode')->willReturn($hitArray);
+
+        $result = $this->viewHelper->render($queryResult, $node, $path);
+        $this->assertEquals($hitArray[$path], $result, 'Just a path from the full hit array will be returned');
+    }
+
+    /**
+     * @test
+     */
+    public function aSingleValueWillBeReturnedForADottedPath()
+    {
+        $singleValue = 'bar';
+        $hitArray = [
+            'foo'   => [
+                0 => $singleValue
+            ],
+            'sort'  => [
+                0 => '14',
+                0 => '14',
+                1 => '18'
+            ]
+        ];
+
+        $node = $this->getMock(NodeInterface::class);
+
+        $queryResult = $this->getMock(ElasticSearchQueryResult::class, array('searchHitForNode'), array(), '', false);
+        $queryResult->expects($this->exactly(2))->method('searchHitForNode')->willReturn($hitArray);
+
+        $singleResult = $this->viewHelper->render($queryResult, $node, 'foo.0');
+        $this->assertEquals($singleValue, $singleResult, 'Only a single value will be returned if path is dotted');
+
+        $fullResult = $this->viewHelper->render($queryResult, $node, 'sort');
+        $this->assertEquals($hitArray['sort'], $fullResult, 'Full array will be returned if there are multiple values');
+    }
+}


### PR DESCRIPTION
This changes adds a generic sort operation that can be used to create any kind of sorting that ElasticSearch supports.