### PR TITLE
[TASK] Add a runtime QueryResult Cache

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQuery.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQuery.php
@@ -25,6 +25,11 @@ class ElasticSearchQuery implements QueryInterface
      */
     protected $queryBuilder;
 
+    /**
+     * @var array
+     */
+    protected static $runtimeQueryResultCache;
+
     public function __construct(ElasticSearchQueryBuilder $elasticSearchQueryBuilder)
     {
         $this->queryBuilder = $elasticSearchQueryBuilder;
@@ -35,7 +40,13 @@ class ElasticSearchQuery implements QueryInterface
      */
     public function execute($cacheResult = false)
     {
-        return new ElasticSearchQueryResult($this);
+        $queryHash = md5(json_encode($this->queryBuilder->getRequest()));
+        if ($cacheResult === true && isset(self::$runtimeQueryResultCache[$queryHash])) {
+            return self::$runtimeQueryResultCache[$queryHash];
+        }
+        $queryResult = new ElasticSearchQueryResult($this);
+        self::$runtimeQueryResultCache[$queryHash] = $queryResult;
+        return $queryResult;
     }
 
     /**

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -671,7 +671,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
     public function execute()
     {
         $elasticSearchQuery = new ElasticSearchQuery($this);
-        $result = $elasticSearchQuery->execute();
+        $result = $elasticSearchQuery->execute(true);
         return $result;
     }
 


### PR DESCRIPTION
A query with the same payload will return the same content from ES, this change adds a runtime cache and implement the support of the ```$cacheResult``` in ```QueryInterface::execute```.

This change also enable the runtime cache by default in the ```ElasticSearchQueryBuilder```