### PR TITLE
BUGFIX: Retrieval of aliases fails with newer API versions

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -460,7 +460,7 @@ class NodeIndexer extends AbstractNodeIndexer
 
         $aliasActions = array();
         try {
-            $response = $this->searchClient->request('GET', '/*/_alias/' . $aliasName);
+            $response = $this->searchClient->request('GET', '/_alias/' . $aliasName);
             if ($response->getStatusCode() !== 200) {
                 throw new Exception('The alias "' . $aliasName . '" was not found with some unexpected error... (return code: ' . $response->getStatusCode() . ')', 1383650137);
             }
@@ -513,7 +513,7 @@ class NodeIndexer extends AbstractNodeIndexer
     {
         $aliasName = $this->searchClient->getIndexName(); // The alias name is the unprefixed index name
 
-        $currentlyLiveIndices = array_keys($this->searchClient->request('GET', '/*/_alias/' . $aliasName)->getTreatedContent());
+        $currentlyLiveIndices = array_keys($this->searchClient->request('GET', '/_alias/' . $aliasName)->getTreatedContent());
 
         $indexStatus = $this->searchClient->request('GET', '/_status')->getTreatedContent();
         $allIndices = array_keys($indexStatus['indices']);


### PR DESCRIPTION
The NodeIndexer tries to retrieve the list of index aliases with a
GET request like `http://localhost:9200/*/_alias/typo3cr´. However,
newer API versions don't seem to support this URL format and fail with
a PatternSyntaxException (Dangling meta character '*').

This fix changes the pattern to `http://localhost:9200/_alias/typo3cr`
which seems to work with both, newer and older API versions.

Tested with Elasticsearch 1.5.2 and 1.7.2.