### PR TITLE
BUGFIX: Fulltext parts are lost on document update

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Indexer/NodeIndexer.php
@@ -164,6 +164,7 @@ class NodeIndexer extends AbstractNodeIndexer
             $mappingType = $this->getIndex()->findType(NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($nodeType));
 
             // Remove document with the same contextPathHash but different NodeType, required after NodeType change
+            $this->logger->log(sprintf('NodeIndexer: Removing node %s from index (if node type changed from %s). ID: %s', $contextPath, $node->getNodeType()->getName(), $contextPathHash), LOG_DEBUG, NULL, 'ElasticSearch (CR)');
             $this->getIndex()->request('DELETE', '/_query', array(), json_encode([
                 'query' => [
                     'bool' => [
@@ -174,7 +175,7 @@ class NodeIndexer extends AbstractNodeIndexer
                         ],
                         'must_not' => [
                             'term' => [
-                                '_type' => str_replace('.', '/', $node->getNodeType()->getName())
+                                '_type' => NodeTypeMappingBuilder::convertNodeTypeNameToMappingName($node->getNodeType()->getName())
                             ]
                         ],
                     ]


### PR DESCRIPTION
Use proper way of mapping node type name to `_type` in index.

Closes #115