### PR TITLE
TASK: Proper escaping for slash in full text query

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -715,7 +715,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
     {
         $this->appendAtPath('query.filtered.query.bool.must', array(
             'query_string' => array(
-                'query' => $searchWord
+                'query' => str_replace('/', '\\/', $searchWord)
             )
         ));
 


### PR DESCRIPTION
Without escaping ElasticSearch return an error for the current query. See https://github.com/elastic/elasticsearch/issues/2980