### PR TITLE
BUGFIX: Index document titles by default

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -116,6 +116,13 @@
     fulltext:
       isRoot: true
   properties:
+    'title':
+      search:
+        elasticSearchMapping:
+          type: string
+          include_in_all: true
+          boost: 20
+
     '__fulltextParts':
       search:
         elasticSearchMapping:


### PR DESCRIPTION
The nodeType `TYPO3.Neos:Document` offers a property `title`. By adding
a `elasticSearchMapping` for this we ensure it is searchable and has the
same priority (`boost`) as `<h1>` titles in the content.