### PR TITLE
TASK: Free memory during indexing after each dimension combination

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
@@ -278,6 +278,9 @@ class NodeIndexCommandController extends CommandController
             $this->outputLine('Workspace "' . $workspaceName . '" and dimensions "' . json_encode($dimensions) . '" done. (Indexed ' . $this->indexedNodes . ' nodes)');
         }
 
+        $this->nodeFactory->reset();
+        $context->getFirstLevelNodeCache()->flush();
+
         $this->countedIndexedNodes = $this->countedIndexedNodes + $this->indexedNodes;
         $this->indexedNodes = 0;
     }


### PR DESCRIPTION
This prevents memory being flooded with all node / dimension combinations data during indexing by clearing caches when a dimension combination was completely indexed