### PR TITLE
TASK: Free memory during indexing after each dimension combination

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Service/IndexWorkspaceTrait.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Service/IndexWorkspaceTrait.php
@@ -84,6 +84,9 @@ trait IndexWorkspaceTrait
 
         $traverseNodes($rootNode, $indexedNodes);
 
+        $this->nodeFactory->reset();
+        $context->getFirstLevelNodeCache()->flush();
+         
         if ($callback !== null) {
             $callback($workspaceName, $indexedNodes, $dimensions);
         }


### PR DESCRIPTION
This prevents memory being flooded with all node / dimension combinations data during indexing by clearing caches when a dimension combination was completely indexed