### PR TITLE
TASK: Implement BulkNodeIndexerInterface in NodeIndexer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_install:
   - git clone https://github.com/neos/neos-base-distribution.git
   - cd neos-base-distribution
   - composer require flowpack/elasticsearch-contentrepositoryadaptor dev-master
+  - composer require typo3/typo3cr-search dev-master
 install:
   - composer install
   - cd ..


### PR DESCRIPTION
This change implements the newly introduced `BulkNodeIndexerInterface` for
the TYPO3.TYPO3CR.Search package. When enabled this skips the check for
duplicate nodes with a different node type. This check is only useful when
changing the node type (live indexing). During the initial indexing this can
speed up the process quite a lot for big indexes.