### PR TITLE
BUGFIX: Correctly determine number of total search results

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -605,9 +605,10 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      */
     public function getTotalItems()
     {
-        if (array_key_exists('total', $this->result)) {
-            return (int)$this->result['total'];
+        if (isset($this->result['hits']['total'])) {
+            return (int)$this->result['hits']['total'];
         }
+        return 0;
     }
 
     /**

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -327,6 +327,23 @@ class ElasticSearchQueryBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function getTotalItemsReturnsZeroByDefault()
+    {
+        $this->assertSame(0, $this->queryBuilder->getTotalItems());
+    }
+
+    /**
+     * @test
+     */
+    public function getTotalItemsReturnsTotalHitsIfItExists()
+    {
+        $this->inject($this->queryBuilder, 'result', ['hits' => ['total' => 123]]);
+        $this->assertSame(123, $this->queryBuilder->getTotalItems());
+    }
+
+    /**
      * Test helper
      *
      * @param $expected


### PR DESCRIPTION
This fixes `ElasticSearchQueryBuilder::getTotalItems()` that was checking
a non-existing result index `total` to retrieve the number of search results.

Fixes: #139