### PR TITLE
TASK: Add a CLI command to index a node by identifier and workspace name

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
@@ -133,6 +133,7 @@ class NodeIndexCommandController extends CommandController
      *
      * @param string $identifier
      * @param string $workspace
+     * @return void
      */
     public function indexNodeCommand($identifier, $workspace = null)
     {
@@ -164,7 +165,7 @@ class NodeIndexCommandController extends CommandController
             $this->nodeIndexer->indexNode($node);
         };
 
-        $indexInWorkspacce = function ($identifier, Workspace $workspace) use ($indexNode) {
+        $indexInWorkspace = function ($identifier, Workspace $workspace) use ($indexNode) {
             $combinations = $this->contentDimensionCombinator->getAllAllowedCombinations();
             if ($combinations === []) {
                 $indexNode($identifier, $workspace, []);
@@ -177,10 +178,10 @@ class NodeIndexCommandController extends CommandController
 
         if ($workspace === null) {
             foreach ($this->workspaceRepository->findAll() as $workspace) {
-                $indexInWorkspacce($identifier, $workspace);
+                $indexInWorkspace($identifier, $workspace);
             }
         } else {
-            $indexInWorkspacce($identifier, $workspace);
+            $indexInWorkspace($identifier, $workspace);
         }
     }
 

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
@@ -143,6 +143,10 @@ class NodeIndexCommandController extends CommandController
         $indexNode = function ($identifier, Workspace $workspace, array $dimensions) {
             $context = $this->createContentContext($workspace->getName(), $dimensions);
             $node = $context->getNodeByIdentifier($identifier);
+            if ($node === null) {
+                $this->outputLine('Node with the given identifier is not found.');
+                $this->quit();
+            }
             $this->outputLine();
             $this->outputLine('Index node "%s" (%s)', [
                 $node->getLabel(),


### PR DESCRIPTION
This change introduce a new CLI command to index a single node in the current index:

    flow nodeindex:indexnode --identifier c480b96f-ee9c-b304-3feb-570182a08236
