### PR TITLE
BUGFIX: Unneeded dependency on TYPO3.Neos package

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
@@ -61,7 +61,7 @@ class NodeIndexCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var \TYPO3\Neos\Domain\Service\ContentDimensionPresetSourceInterface
+     * @var \TYPO3\TYPO3CR\Domain\Service\ContentDimensionPresetSourceInterface
      */
     protected $contentDimensionPresetSource;
 


### PR DESCRIPTION
The contentDimensionPresetSource was typehinted to the Neos
ContentDimensionPresetSourceInterface from the TYPO3.Neos
package. This interface is based on the corresponding
ContentDimensionPresetSourceInterface interface in the TYPO3.TYPO3CR
package.

As the command controller does not make use of the additional
method on the interface in the Neos package the use of it is
useless.

This change changes the type hint to the TYPO3.TYPO3CR package
so the Elastic content repository adaptor can be installed without
the TYPO3.Neos package.