### PR TITLE
BUGIFX: Remove useless variable in traverseNodes callback

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Service/IndexWorkspaceTrait.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Service/IndexWorkspaceTrait.php
@@ -71,7 +71,7 @@ trait IndexWorkspaceTrait
         $rootNode = $context->getRootNode();
         $indexedNodes = 0;
 
-        $traverseNodes = function (NodeInterface $currentNode, &$indexedNodes) use ($limit, &$indexedNodes, &$traverseNodes) {
+        $traverseNodes = function (NodeInterface $currentNode, &$indexedNodes) use ($limit, &$traverseNodes) {
             if ($limit !== null && $indexedNodes > $limit) {
                 return;
             }


### PR DESCRIPTION
This change solve issue with PHP 7.1 that don't allow it.