### PR TITLE
FEATURE: Index the node property `_hiddenInIndex`

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -165,6 +165,9 @@
               type: string
               include_in_all: true
               boost: 1
+    '_hiddenInIndex':
+      search:
+        indexing: '${node.hiddenInIndex}'
 
 'TYPO3.Neos.NodeTypes:Text':
   properties:


### PR DESCRIPTION
This will correctly index the status of the “Hide in menus” checkbox
on documents.