### PR TITLE
FEATURE: Make amount of buckets configurable via fusion

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -435,17 +435,19 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      *
      * Access all aggregation data with {nodes.aggregations} in your fluid template
      *
-     * @param $name
-     * @param $field
-     * @param string $type
-     * @param null $parentPath
+     * @param string $name The name to identify the resulting aggregation
+     * @param string $field The field to aggregate by
+     * @param string $type Aggregation type
+     * @param string $parentPath
+     * @param int $size The amount of buckets to return
      * @return $this
      */
-    public function fieldBasedAggregation($name, $field, $type = "terms", $parentPath = null)
+    public function fieldBasedAggregation($name, $field, $type = 'terms', $parentPath = '', $size = 10)
     {
         $aggregationDefinition = [
             $type => [
-                'field' => $field
+                'field' => $field,
+                'size' => $size
             ]
         ];
 
@@ -471,17 +473,17 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      *
      * @param string $name
      * @param array $aggregationDefinition
-     * @param null $parentPath
+     * @param string $parentPath
      * @return $this
      * @throws QueryBuildingException
      */
-    public function aggregation($name, array $aggregationDefinition, $parentPath = null)
+    public function aggregation($name, array $aggregationDefinition, $parentPath = '')
     {
-        if (!array_key_exists("aggregations", $this->request)) {
+        if (!array_key_exists('aggregations', $this->request)) {
             $this->request['aggregations'] = [];
         }
 
-        if ($parentPath !== null) {
+        if ($parentPath !== '') {
             $this->addSubAggregation($parentPath, $name, $aggregationDefinition);
         } else {
             $this->request['aggregations'][$name] = $aggregationDefinition;
@@ -507,9 +509,9 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         // Find the parentPath
         $path =& $this->request['aggregations'];
 
-        foreach (explode(".", $parentPath) as $subPart) {
+        foreach (explode('.', $parentPath) as $subPart) {
             if ($path == null || !array_key_exists($subPart, $path)) {
-                throw new QueryBuildingException("The parent path " . $subPart . " could not be found when adding a sub aggregation");
+                throw new QueryBuildingException('The parent path ' . $subPart . ' could not be found when adding a sub aggregation');
             }
             $path =& $path[$subPart]['aggregations'];
         }

--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ Right now there are two methods implemented. One generic `aggregation` function 
 aggregation definition and a pre-configured `fieldBasedAggregation`. Both methods can be added to your TS search query.
 You can nest aggregations by providing a parent name.
 
-* `aggregation($name, array $aggregationDefinition, $parentPath = NULL)` -- generic method to add a $aggregationDefinition under a path $parentPath with the name $name
-* `fieldBasedAggregation($name, $field, $type = "terms", $parentPath = NULL)` -- adds a simple filed based Aggregation of type $type with name $name under path $parentPath. Used for simple aggregations like sum, avg, min, max or terms
+* `aggregation($name, array $aggregationDefinition, $parentPath = NULL)` -- generic method to add a $aggregationDefinition under a path $parentPath with the name $name.
+* `fieldBasedAggregation($name, $field, $type = 'terms', $parentPath = '' size = 10)` -- adds a simple filed based Aggregation of type $type with name $name under path $parentPath. Used for simple aggregations like sum, avg, min, max or terms. By default 10 buckets are returned.
 
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ aggregation definition and a pre-configured `fieldBasedAggregation`. Both method
 You can nest aggregations by providing a parent name.
 
 * `aggregation($name, array $aggregationDefinition, $parentPath = NULL)` -- generic method to add a $aggregationDefinition under a path $parentPath with the name $name.
-* `fieldBasedAggregation($name, $field, $type = 'terms', $parentPath = '' size = 10)` -- adds a simple filed based Aggregation of type $type with name $name under path $parentPath. Used for simple aggregations like sum, avg, min, max or terms. By default 10 buckets are returned.
+* `fieldBasedAggregation($name, $field, $type = 'terms', $parentPath = '', $size = 10)` -- adds a simple filed based Aggregation of type $type with name $name under path $parentPath. Used for simple aggregations like sum, avg, min, max or terms. By default 10 buckets are returned.
 
 
 ### Examples


### PR DESCRIPTION
By default, elasticsearch retruns 10 buckets for a term aggregation.
This change makes the size value configurable via fusion.