### PR TITLE
BUGFIX: Unneeded dependency on TYPO3.Neos package

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -52,7 +52,7 @@ class NodeIndexCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var \Neos\Neos\Domain\Service\ContentDimensionPresetSourceInterface
+     * @var \Neos\ContentRepository\Domain\Service\ContentDimensionPresetSourceInterface
      */
     protected $contentDimensionPresetSource;
 


### PR DESCRIPTION
The contentDimensionPresetSource was typehinted to the Neos
ContentDimensionPresetSourceInterface from the TYPO3.Neos
package. This interface is based on the corresponding
ContentDimensionPresetSourceInterface interface in the TYPO3.TYPO3CR
package.

As the command controller does not make use of the additional
method on the interface in the Neos package the use of it is
useless.

This change changes the type hint to the TYPO3.TYPO3CR package
so the Elastic content rpeository adaptor can be installed without
the TYPO3.Neos package.