### PR TITLE
BUGFIX: Make indexing work on hidden content

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -249,7 +249,11 @@ class NodeIndexCommandController extends CommandController
     protected function indexWorkspaceWithDimensions($workspaceName, array $dimensions = [])
     {
         $indexedNodes = 0;
-        $context = $this->contextFactory->create(['workspaceName' => $workspaceName, 'dimensions' => $dimensions]);
+        $context = $this->contextFactory->create([
+            'workspaceName' => $workspaceName,
+            'dimensions' => $dimensions,
+            'invisibleContentShown' => true
+        ]);
         $rootNode = $context->getRootNode();
 
         $indexedNodes += $this->traverseNodes($rootNode);

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -222,7 +222,8 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
             foreach ($dimensionCombinations as $combination) {
                 $context = $this->contextFactory->create([
                     'workspaceName' => $workspaceName,
-                    'dimensions' => $combination
+                    'dimensions' => $combination,
+                    'invisibleContentShown' => true
                 ]);
                 $node = $context->getNodeByIdentifier($nodeIdentifier);
                 if ($node !== null) {
@@ -230,7 +231,10 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
                 }
             }
         } else {
-            $context = $this->contextFactory->create(['workspaceName' => $workspaceName]);
+            $context = $this->contextFactory->create([
+                'workspaceName' => $workspaceName,
+                'invisibleContentShown' => true
+            ]);
             $node = $context->getNodeByIdentifier($nodeIdentifier);
             if ($node !== null) {
                 $indexer($node, $targetWorkspaceName);

--- a/Classes/Service/IndexWorkspaceTrait.php
+++ b/Classes/Service/IndexWorkspaceTrait.php
@@ -67,7 +67,11 @@ trait IndexWorkspaceTrait
      */
     protected function indexWorkspaceWithDimensions($workspaceName, array $dimensions = [], $limit = null, callable $callback = null)
     {
-        $context = $this->contextFactory->create(['workspaceName' => $workspaceName, 'dimensions' => $dimensions]);
+        $context = $this->contextFactory->create([
+            'workspaceName' => $workspaceName,
+            'dimensions' => $dimensions,
+            'invisibleContentShown' => true
+        ]);
         $rootNode = $context->getRootNode();
         $indexedNodes = 0;
 


### PR DESCRIPTION
The node indexing uses a content context which does not
return hidden content. This means hidden nodes are
not imported while the _hidden property is mapped and
excluded from queries by default.