### PR TITLE
!!! TASK: Adjust the result of getSuggestions

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -422,7 +422,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      *
      * nodes = ${Search....termSuggestions("aTerm")}
      *
-     * Access all suggestions data with {nodes.suggestions} in your fluid template
+     * Access all suggestions data with ${Search....getSuggestions()}
      *
      * @param string $text
      * @param string $field

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryResult.php
@@ -208,20 +208,32 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
     }
 
     /**
+     * Returns an array of type
+     * [
+     *     <suggestionName> => [
+     *         'text' => <term>
+     *         'options' => [
+     *              [
+     *               'text' => <suggestionText>
+     *               'score' => <score>
+     *              ],
+     *              [
+     *              ...
+     *              ]
+     *         ]
+     *     ]
+     * ]
+     *
      * @return array
      */
     public function getSuggestions()
     {
         $this->initialize();
-        if (count($this->result['suggest']) === 1) {
-            $suggestArray = current($this->result['suggest']);
-
-            if (count($suggestArray) === 1) {
-                return current($suggestArray);
-            }
+        if (array_key_exists('suggest', $this->result)) {
+            return $this->result['suggest'];
         }
 
-        return $this->result['suggest'];
+        return [];
     }
 
     /**

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -213,19 +213,23 @@ class ElasticSearchQueryTest extends FunctionalTestCase
      */
     public function termSuggestion()
     {
-        $titleSuggestionKey = "chickn";
+        $titleSuggestionKey = 'chickn';
 
         $result = $this->getQueryBuilder()
             ->log($this->getLogMessagePrefix(__METHOD__))
-            ->termSuggestions($titleSuggestionKey, "title")
+            ->termSuggestions($titleSuggestionKey, 'title')
             ->execute()
             ->getSuggestions();
 
-        $this->assertArrayHasKey("options", $result);
+        $this->assertArrayHasKey('suggestions', $result);
+        $this->assertTrue(is_array($result['suggestions']), 'Suggestions must be an array.');
+        $firstSuggestion = current($result['suggestions']);
 
-        $this->assertCount(1, $result['options']);
+        $this->assertArrayHasKey('options', $firstSuggestion);
 
-        $this->assertEquals('chicken', $result['options'][0]['text']);
+        $this->assertCount(1, $firstSuggestion['options']);
+
+        $this->assertEquals('chicken', $firstSuggestion['options'][0]['text']);
     }
 
     /**


### PR DESCRIPTION
Before the result of ``getSuggestions`` returned the suggestion of a search term if the term only consisted of one word. When the search term consisted of two words it returned the complete array. This is an absolutely unexpected behavior. It was also only possible to access the first defined suggest term.

This change now returns the complete suggestion array, so it behaves like the comparable aggregation getter.