### PR TITLE
FEATURE: Make amount of buckets configurable via fusion

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Driver/AbstractQuery.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Driver/AbstractQuery.php
@@ -96,13 +96,13 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
     /**
      * {@inheritdoc}
      */
-    public function aggregation($name, array $aggregationDefinition, $parentPath = null)
+    public function aggregation($name, array $aggregationDefinition, $parentPath = '')
     {
         if (!array_key_exists('aggregations', $this->request)) {
             $this->request['aggregations'] = [];
         }
 
-        if ($parentPath !== null) {
+        if ((string)$parentPath !== '') {
             $this->addSubAggregation($parentPath, $name, $aggregationDefinition);
         } else {
             $this->request['aggregations'][$name] = $aggregationDefinition;
@@ -116,8 +116,8 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
      * insert your $aggregationConfiguration under
      * $this->request['aggregations']['foo']['aggregations']['bar']['aggregations'][$name]
      *
-     * @param $parentPath
-     * @param $name
+     * @param string $parentPath The parent path to add the sub aggregation to
+     * @param string $name The name to identify the resulting aggregation
      * @param array $aggregationConfiguration
      * @return QueryInterface
      * @throws Exception\QueryBuildingException
@@ -127,9 +127,9 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
         // Find the parentPath
         $path =& $this->request['aggregations'];
 
-        foreach (explode(".", $parentPath) as $subPart) {
+        foreach (explode('.', $parentPath) as $subPart) {
             if ($path == null || !array_key_exists($subPart, $path)) {
-                throw new Exception\QueryBuildingException("The parent path " . $subPart . " could not be found when adding a sub aggregation");
+                throw new Exception\QueryBuildingException(sprintf('The parent path segment "%s" could not be found when adding a sub aggregation to parent path "%s"', $subPart, $parentPath));
             }
             $path =& $path[$subPart]['aggregations'];
         }

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Driver/QueryInterface.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Driver/QueryInterface.php
@@ -91,14 +91,14 @@ interface QueryInterface
     /**
      * This method is used to create any kind of aggregation.
      *
-     * @param string $name
+     * @param string $name The name to identify the resulting aggregation
      * @param array $aggregationDefinition
-     * @param string $parentPath
+     * @param string $parentPath ParentPath to define the parent of a sub aggregation
      * @return void
      * @api
      * @throws Exception\QueryBuildingException
      */
-    public function aggregation($name, array $aggregationDefinition, $parentPath = null);
+    public function aggregation($name, array $aggregationDefinition, $parentPath = '');
 
     /**
      * This method is used to create any kind of suggestion.

--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Eel/ElasticSearchQueryBuilder.php
@@ -368,17 +368,19 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      *
      * Access all aggregation data with {nodes.aggregations} in your fluid template
      *
-     * @param $name
-     * @param $field
-     * @param string $type
-     * @param null $parentPath
+     * @param string $name The name to identify the resulting aggregation
+     * @param string $field The field to aggregate by
+     * @param string $type Aggregation type
+     * @param string $parentPath
+     * @param int $size The amount of buckets to return
      * @return $this
      */
-    public function fieldBasedAggregation($name, $field, $type = "terms", $parentPath = null)
+    public function fieldBasedAggregation($name, $field, $type = 'terms', $parentPath = '', $size = 10)
     {
         $aggregationDefinition = [
             $type => [
-                'field' => $field
+                'field' => $field,
+                'size' => $size
             ]
         ];
 
@@ -404,11 +406,11 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      *
      * @param string $name
      * @param array $aggregationDefinition
-     * @param null $parentPath
+     * @param string $parentPath
      * @return $this
      * @throws QueryBuildingException
      */
-    public function aggregation($name, array $aggregationDefinition, $parentPath = null)
+    public function aggregation($name, array $aggregationDefinition, $parentPath = '')
     {
         $this->request->aggregation($name, $aggregationDefinition, $parentPath);
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ Right now there are two methods implemented. One generic `aggregation` function 
 aggregation definition and a pre-configured `fieldBasedAggregation`. Both methods can be added to your TS search query.
 You can nest aggregations by providing a parent name.
 
-* `aggregation($name, array $aggregationDefinition, $parentPath = NULL)` -- generic method to add a $aggregationDefinition under a path $parentPath with the name $name
-* `fieldBasedAggregation($name, $field, $type = "terms", $parentPath = NULL)` -- adds a simple filed based Aggregation of type $type with name $name under path $parentPath. Used for simple aggregations like sum, avg, min, max or terms
+* `aggregation($name, array $aggregationDefinition, $parentPath = NULL)` -- generic method to add a $aggregationDefinition under a path $parentPath with the name $name.
+* `fieldBasedAggregation($name, $field, $type = 'terms', $parentPath = '', $size = 10)` -- adds a simple filed based Aggregation of type $type with name $name under path $parentPath. Used for simple aggregations like sum, avg, min, max or terms. By default 10 buckets are returned.
 
 
 ### Examples

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -279,29 +279,35 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
     public function simpleAggregationExamples()
     {
         return [
-            ['min', 'foo', 'bar'],
-            ['terms', 'foo', 'bar'],
-            ['sum', 'foo', 'bar'],
-            ['stats', 'foo', 'bar'],
-            ['value_count', 'foo', 'bar']
+            ['min', 'foo', 'bar', 10],
+            ['terms', 'foo', 'bar', 10],
+            ['sum', 'foo', 'bar', 10],
+            ['stats', 'foo', 'bar', 10],
+            ['value_count', 'foo', 'bar', 20]
         ];
     }
 
     /**
      * @test
      * @dataProvider simpleAggregationExamples
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $field
+     * @param integer size
      */
-    public function anSimpleAggregationCanBeAddedToTheRequest($type, $name, $field)
+    public function anSimpleAggregationCanBeAddedToTheRequest($type, $name, $field, $size)
     {
         $expected = [
             $name => [
                 $type => [
-                    'field' => $field
+                    'field' => $field,
+                    'size' => $size
                 ]
             ]
         ];
 
-        $this->queryBuilder->fieldBasedAggregation($name, $field, $type);
+        $this->queryBuilder->fieldBasedAggregation($name, $field, $type, '', $size);
         $actual = $this->queryBuilder->getRequest()->toArray();
 
         $this->assertInArray($expected, $actual);
@@ -312,19 +318,28 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
      */
     public function anAggregationCanBeSubbedUnderAPath()
     {
-        $this->queryBuilder->fieldBasedAggregation("foo", "bar");
-        $this->queryBuilder->fieldBasedAggregation("bar", "bar", "terms", "foo");
-        $this->queryBuilder->fieldBasedAggregation("baz", "bar", "terms", "foo.bar");
+        $this->queryBuilder->fieldBasedAggregation('foo', 'bar');
+        $this->queryBuilder->fieldBasedAggregation('bar', 'bar', 'terms', 'foo');
+        $this->queryBuilder->fieldBasedAggregation('baz', 'bar', 'terms', 'foo.bar');
 
         $expected = [
-            "foo" => [
-                "terms" => ["field" => "bar"],
-                "aggregations" => [
-                    "bar" => [
-                        "terms" => ["field" => "bar"],
-                        "aggregations" => [
-                            "baz" => [
-                                "terms" => ["field" => "bar"]
+            'foo' => [
+                'terms' => [
+                    'field' => 'bar',
+                    'size' => 10
+                ],
+                'aggregations' => [
+                    'bar' => [
+                        'terms' => [
+                            'field' => 'bar',
+                            'size' => 10
+                        ],
+                        'aggregations' => [
+                            'baz' => [
+                                'terms' => [
+                                    'field' => 'bar',
+                                    'size' => 10
+                                ],
                             ]
                         ]
                     ]


### PR DESCRIPTION
By default, elasticsearch returns 10 buckets for a term aggregation.
This change makes the size value configurable via fusion.

Also improves some header comments.
This is a rebuild-PR against new 3.0.