### PR TITLE
BUGFIX: Include the context document in the query result

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -651,7 +651,17 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         // on indexing, the __parentPath is tokenized to contain ALL parent path parts,
         // e.g. /foo, /foo/bar/, /foo/bar/baz; to speed up matching.. That's why we use a simple "term" filter here.
         // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-term-filter.html
-        $this->queryFilter('term', ['__parentPath' => $contextNode->getPath()]);
+        // another term filter against the path allows the context node itself to be found
+        $this->queryFilter('bool', [
+            'should' => [
+                [
+                    'term' => ['__parentPath' => $contextNode->getPath()]
+                ],
+                [
+                    'term' => ['__path' => $contextNode->getPath()]
+                ]
+            ]
+        ]);
 
         //
         // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-terms-filter.html

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -140,7 +140,7 @@ class ElasticSearchQueryTest extends FunctionalTestCase
             ->log($this->getLogMessagePrefix(__METHOD__))
             ->nodeType('TYPO3.Neos.NodeTypes:Page')
             ->count();
-        $this->assertEquals(3, $resultCount);
+        $this->assertEquals(4, $resultCount);
     }
 
     /**
@@ -166,7 +166,7 @@ class ElasticSearchQueryTest extends FunctionalTestCase
             ->limit(1);
 
         $resultCount = $query->count();
-        $this->assertEquals(3, $resultCount, 'Asserting the count query returns the total count.');
+        $this->assertEquals(4, $resultCount, 'Asserting the count query returns the total count.');
     }
 
     /**
@@ -198,7 +198,7 @@ class ElasticSearchQueryTest extends FunctionalTestCase
 
         $this->assertArrayHasKey($aggregationTitle, $result);
 
-        $this->assertCount(2, $result[$aggregationTitle]['buckets']);
+        $this->assertCount(3, $result[$aggregationTitle]['buckets']);
 
         $expectedChickenBucket = [
             'key' => 'chicken',
@@ -268,13 +268,13 @@ class ElasticSearchQueryTest extends FunctionalTestCase
         /** @var QueryResultInterface $result $node */
 
         $this->assertInstanceOf(QueryResultInterface::class, $result);
-        $this->assertCount(3, $result, 'The result should have 3 items');
-        $this->assertEquals(3, $result->count(), 'Count should be 3');
+        $this->assertCount(4, $result, 'The result should have 3 items');
+        $this->assertEquals(4, $result->count(), 'Count should be 3');
 
         $node = $result->getFirst();
 
         $this->assertInstanceOf(NodeInterface::class, $node);
-        $this->assertEquals('egg', $node->getProperty('title'), 'Asserting a desc sort order by property title');
+        $this->assertEquals('welcome', $node->getProperty('title'), 'Asserting a desc sort order by property title');
     }
 
     /**

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -111,8 +111,19 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                         'bool' => [
                             'must' => [
                                 0 => [
-                                    'term' => [
-                                        '__parentPath' => '/foo/bar'
+                                    'bool' => [
+                                        'should' => [
+                                            0 => [
+                                                'term' => [
+                                                    '__parentPath' => '/foo/bar'
+                                                ]
+                                            ],
+                                            1 => [
+                                                'term' => [
+                                                    '__path' => '/foo/bar'
+                                                ]
+                                            ]
+                                        ]
                                     ]
                                 ],
                                 1 => [


### PR DESCRIPTION
The ElasticSearchQueryBuilder::query searches only below the given context
document.

One example when this is wrong is when you search from the site node, which
you use as the homepage - in this case the actual "homepage" would not be
searched.