### PR TITLE
BUGFIX: Index by alias, treated content

### DIFF
--- a/Classes/Driver/Version1/IndexDriver.php
+++ b/Classes/Driver/Version1/IndexDriver.php
@@ -56,6 +56,8 @@ class IndexDriver extends AbstractDriver implements IndexDriverInterface
             throw new Exception('The alias "' . $alias . '" was not found with some unexpected error... (return code: ' . $response->getStatusCode() . ')', 1383650137);
         }
 
-        return array_keys($response->getTreatedContent());
+        // return empty array if content from response cannot be read as an array
+        $treatedContent = $response->getTreatedContent();
+        return is_array($treatedContent) ? array_keys($treatedContent) : [];
     }
 }

--- a/Classes/Driver/Version1/IndexDriver.php
+++ b/Classes/Driver/Version1/IndexDriver.php
@@ -52,7 +52,7 @@ class IndexDriver extends AbstractDriver implements IndexDriverInterface
     public function indexesByAlias($alias)
     {
         $response = $this->searchClient->request('GET', '/_alias/' . $alias);
-        if ($response->getStatusCode() !== 200) {
+        if ($response->getStatusCode() !== 200 && $response->getStatusCode() !== 404) {
             throw new Exception('The alias "' . $alias . '" was not found with some unexpected error... (return code: ' . $response->getStatusCode() . ')', 1383650137);
         }
 


### PR DESCRIPTION
If you search for index that not exists, it triggers error (and should not as the code handle the creation after that).

And sometimes (perhaps due to utilisation of Elastic Cloud), treated response is null/not array so an error is triggered. Simply ensure here a empty array is returned if treated content is not an array.