### PR TITLE
BUGFIX: Fix nodeindex:cleanup command for ES >= 2.0

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -270,7 +270,7 @@ class NodeIndexCommandController extends CommandController
             }
         } catch (\Flowpack\ElasticSearch\Transfer\Exception\ApiException $exception) {
             $response = json_decode($exception->getResponse());
-            $this->logger->log(sprintf('Nothing removed. ElasticSearch responded with status %s, saying "%s"', $response->status, $response->error));
+            $this->logger->log(sprintf('Nothing removed. ElasticSearch responded with status %s, saying "%s: %s"', $response->status, $response->error->type, $response->error->reason));
         }
     }
 }

--- a/Classes/Driver/Version2/SystemDriver.php
+++ b/Classes/Driver/Version2/SystemDriver.php
@@ -21,4 +21,11 @@ use TYPO3\Flow\Annotations as Flow;
  */
 class SystemDriver extends Version1\SystemDriver
 {
+    /**
+     * @inheritDoc
+     */
+    public function status()
+    {
+        return $this->searchClient->request('GET', '/_stats')->getTreatedContent();
+    }
 }


### PR DESCRIPTION
- In the cleanup command there was a regression introduced with 314ecac2cb88055b724943e9ad96bb6fb10f1cac where it tried to log an object.
- In ESv2 /_status [was removed](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_stats_info_and_literal_cat_literal_changes.html#_index_status_api) in [favor of /_stats](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/indices-status.html).

This replaces PR #200 and targets branch 3.0.