### PR TITLE
BUGFIX: do not iterate over all dimensions to traverse the nodetree only once

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -141,6 +141,8 @@ class NodeIndexCommandController extends CommandController
             $workspace = 'live';
         }
 
+        $defaultDimensionCombination = $this->getDefaultDimensionCombination();
+
         $indexNode = function ($identifier, Workspace $workspace, array $dimensions) {
             $context = $this->createContentContext($workspace->getName(), $dimensions);
             $node = $context->getNodeByIdentifier($identifier);
@@ -165,15 +167,8 @@ class NodeIndexCommandController extends CommandController
             $this->nodeIndexer->indexNode($node);
         };
 
-        $indexInWorkspace = function ($identifier, Workspace $workspace) use ($indexNode) {
-            $combinations = $this->contentDimensionCombinator->getAllAllowedCombinations();
-            if ($combinations === []) {
-                $indexNode($identifier, $workspace, []);
-            } else {
-                foreach ($combinations as $combination) {
-                    $indexNode($identifier, $workspace, $combination);
-                }
-            }
+        $indexInWorkspace = function ($identifier, Workspace $workspace) use ($indexNode, $defaultDimensionCombination) {
+            $indexNode($identifier, $workspace, $defaultDimensionCombination);
         };
 
         if ($workspace === null) {

--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -225,7 +225,7 @@ class NodeIndexCommandController extends CommandController
             if ($dimensions === []) {
                 $this->outputLine('Workspace "' . $workspaceName . '" without dimensions done. (Indexed ' . $indexedNodes . ' nodes)');
             } else {
-                $this->outputLine('Workspace "' . $workspaceName . '" and dimensions "' . json_encode($dimensions) . '" done. (Indexed ' . $indexedNodes . ' nodes)');
+                $this->outputLine('Workspace "' . $workspaceName . '" including dimensions done. (Indexed ' . $indexedNodes . ' nodes)');
             }
         };
         if ($workspace === null) {

--- a/Classes/Service/IndexWorkspaceTrait.php
+++ b/Classes/Service/IndexWorkspaceTrait.php
@@ -46,14 +46,9 @@ trait IndexWorkspaceTrait
     protected function indexWorkspace($workspaceName, $limit = null, callable $callback = null)
     {
         $count = 0;
-        $combinations = $this->contentDimensionCombinator->getAllAllowedCombinations();
-        if ($combinations === []) {
-            $count += $this->indexWorkspaceWithDimensions($workspaceName, [], $limit, $callback);
-        } else {
-            foreach ($combinations as $combination) {
-                $count += $this->indexWorkspaceWithDimensions($workspaceName, $combination, $limit, $callback);
-            }
-        }
+        $defaultDimensionCombination = $this->getDefaultDimensionCombination();
+
+        $count += $this->indexWorkspaceWithDimensions($workspaceName, $defaultDimensionCombination, $limit, $callback);
 
         return $count;
     }
@@ -93,4 +88,22 @@ trait IndexWorkspaceTrait
 
         return $indexedNodes;
     }
-}
+
+    /**
+     * @return array
+     */
+    protected function getDefaultDimensionCombination()
+    {
+        $defaultCombination = array();
+
+        $allDimensionPresets = $this->contentDimensionPresetSource->getAllPresets();
+        $dimensionNames = array_keys($allDimensionPresets);
+        $dimensionCount = count($dimensionNames);
+        if ($dimensionCount > 0) {
+            foreach ($dimensionNames as $dimensionName) {
+                $defaultCombination[$dimensionName] = $this->contentDimensionPresetSource->getDefaultPreset($dimensionName)['values'];
+            }
+        }
+
+        return $defaultCombination;
+    }}

--- a/Classes/Service/IndexWorkspaceTrait.php
+++ b/Classes/Service/IndexWorkspaceTrait.php
@@ -106,4 +106,5 @@ trait IndexWorkspaceTrait
         }
 
         return $defaultCombination;
-    }}
+    }
+}


### PR DESCRIPTION
In our opinion the we don't need the allowed dimension combinations upfront ([here](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/blob/3.0/Classes/Command/NodeIndexCommandController.php#L169) and [here](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/blob/3.0/Classes/Service/IndexWorkspaceTrait.php#L49)), because the dimensions get loaded anyway in the NodeIndexer ([here](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/blob/3.0/Classes/Indexer/NodeIndexer.php#L240)).

Or do we overlook something and it's not enough to deliver a proper default dimension to create the root node?