### PR TITLE
BUGFIX: Remove unneeded depency on Neos

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -287,15 +287,15 @@ class NodeIndexCommandController extends CommandController
      * @param array $dimensions Optional list of dimensions and their values which should be set
      * @return Context
      */
-    protected function createContentContext($workspaceName, array $dimensions = array())
+    protected function createContentContext($workspaceName, array $dimensions = [])
     {
-        $contextProperties = array(
+        $contextProperties = [
             'workspaceName' => $workspaceName,
             'invisibleContentShown' => true,
             'inaccessibleContentShown' => true
-        );
+        ];
 
-        if ($dimensions !== array()) {
+        if ($dimensions !== []) {
             $contextProperties['dimensions'] = $dimensions;
             $contextProperties['targetDimensions'] = array_map(function ($dimensionValues) {
                 return array_shift($dimensionValues);


### PR DESCRIPTION
The NodeIndexCommandController used a trait from Neos
which adds just little value while adding a strong dependency
to Neos which conflicts with the content repository requirement
to run 'standalone'.

Resolves #209