### PR TITLE
TASK: Force `__fulltextParts` to a HashMap

### DIFF
--- a/Classes/Driver/Version1/IndexerDriver.php
+++ b/Classes/Driver/Version1/IndexerDriver.php
@@ -114,7 +114,7 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
             [
                 // first, update the __fulltextParts, then re-generate the __fulltext from all __fulltextParts
                 'script' => '
-                    if (!ctx._source.containsKey("__fulltextParts")) {
+                    if (!(ctx._source.containsKey("__fulltextParts") && ctx._source.__fulltextParts instanceof HashMap)) {
                         ctx._source.__fulltextParts = new LinkedHashMap();
                     }
 

--- a/Classes/Driver/Version2/IndexerDriver.php
+++ b/Classes/Driver/Version2/IndexerDriver.php
@@ -123,11 +123,11 @@ class IndexerDriver extends Version1\IndexerDriver
                 'script' => [
                     'inline' => '
                         ctx._source.__fulltext = new HashMap();
-                        
-                        if (!ctx._source.containsKey("__fulltextParts")) {
+
+                        if (!(ctx._source.containsKey("__fulltextParts") && ctx._source.__fulltextParts instanceof HashMap)) {
                             ctx._source.__fulltextParts = new HashMap();
                         }
-                        
+
                         if (nodeIsRemoved || nodeIsHidden || fulltext.size() == 0) {
                             if (ctx._source.__fulltextParts.containsKey(identifier)) {
                                 ctx._source.__fulltextParts.remove(identifier);
@@ -135,7 +135,7 @@ class IndexerDriver extends Version1\IndexerDriver
                         } else {
                             ctx._source.__fulltextParts.put(identifier, fulltext);
                         }
-    
+
                         ctx._source.__fulltextParts.each { originNodeIdentifier, partContent -> partContent.each { bucketKey, content ->
                                 if (ctx._source.__fulltext.containsKey(bucketKey)) {
                                     value = ctx._source.__fulltext[bucketKey] + " " + content.trim();


### PR DESCRIPTION
For some reason `__fulltextParts` is sometimes an empty array which prevents the groovy script from "putting" into it. In this case, this pull requests reinitializes the `_fulltextParts`as a new hashmap.