### PR TITLE
BUGFIX: Avoid creating workspaces in nodeindex:build

### DIFF
--- a/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
@@ -181,8 +181,12 @@ class NodeIndexCommandController extends CommandController
                 $indexInWorkspace($identifier, $workspace);
             }
         } else {
-            $workspace = $this->workspaceRepository->findByIdentifier($workspace);
-            $indexInWorkspace($identifier, $workspace);
+            $workspaceInstance = $this->workspaceRepository->findByIdentifier($workspace);
+            if ($workspaceInstance === null) {
+                $this->outputLine('The given workspace (%s) does not exist.', [$workspace]);
+                $this->quit(1);
+            }
+            $indexInWorkspace($identifier, $workspaceInstance);
         }
     }
 
@@ -199,6 +203,11 @@ class NodeIndexCommandController extends CommandController
      */
     public function buildCommand($limit = null, $update = false, $workspace = null, $postfix = null)
     {
+        if ($workspace !== null && $this->workspaceRepository->findByIdentifier($workspace) === null) {
+            $this->logger->log('The given workspace (' . $workspace . ') does not exist.', LOG_ERR);
+            $this->quit(1);
+        }
+
         if ($update === true) {
             $this->logger->log('!!! Update Mode (Development) active!', LOG_INFO);
         } else {


### PR DESCRIPTION
When the name of a non-existing workspace was given to `nodeindex:build`,
that work was implicitly created (due to some legacy default behaviour of the
content repository).

This change adds a check and stops when the workspace does not exist.

The `nodeindex:indexnode` command did not cause workspace creation,
but now shows an error message, instead of an exception. Covfefe!

Fixes issue #213