### PR TITLE
Allow DimensionCombination Presets to define what's to index

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -314,5 +314,4 @@ class NodeIndexCommandController extends CommandController
 
         return $this->contextFactory->create($contextProperties);
     }
-
 }

--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -205,9 +205,10 @@ class NodeIndexCommandController extends CommandController
      * @param boolean $update if TRUE, do not throw away the index at the start. Should *only be used for development*.
      * @param string $workspace name of the workspace which should be indexed
      * @param string $postfix Index postfix, index with the same postifix will be deleted if exist
+     * @param string $dimensionsPreset Select a custom preset to limit the indexed dimension combinations
      * @return void
      */
-    public function buildCommand($limit = null, $update = false, $workspace = null, $postfix = null)
+    public function buildCommand($limit = null, $update = false, $workspace = null, $postfix = null, $dimensionsPreset = null)
     {
         if ($workspace !== null && $this->workspaceRepository->findByIdentifier($workspace) === null) {
             $this->logger->log('The given workspace (' . $workspace . ') does not exist.', LOG_ERR);
@@ -250,10 +251,10 @@ class NodeIndexCommandController extends CommandController
         };
         if ($workspace === null) {
             foreach ($this->workspaceRepository->findAll() as $workspace) {
-                $count += $this->indexWorkspace($workspace->getName(), $limit, $callback);
+                $count += $this->indexWorkspace($workspace->getName(), $limit, $callback, $dimensionsPreset);
             }
         } else {
-            $count += $this->indexWorkspace($workspace, $limit, $callback);
+            $count += $this->indexWorkspace($workspace, $limit, $callback, $dimensionsPreset);
         }
 
         $this->nodeIndexingManager->flushQueues();

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -103,6 +103,24 @@ Flowpack:
               className: Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version2\RequestDriver
             system:
               className: Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version2\SystemDriver
+
+      indexDimensionCombinationPreset: default
+      indexDimensionCombinationPresets:
+        default: []
+#        customExample:
+#          -
+#            language:
+#              - de
+#              - en
+#            country:
+#              - GLOBAL
+#          -
+#            language:
+#              - fr
+#              - en
+#            country:
+#              - GLOBAL
+
 Neos:
   ContentRepository:
     Search:


### PR DESCRIPTION
As a Feature-Replacement for #206

If you have a lot of DimensionCombinations to structure your content, but you need only a few of them in the index.. then you can save a lot of time with this limitation.