### PR TITLE
Change "_count" to "_search" for the .count() method

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -593,11 +593,11 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         $timeBefore = microtime(true);
         $request = $this->getRequest()->getCountRequestAsJson();
 
-        $response = $this->elasticSearchClient->getIndex()->request('GET', '/_count', [], $request);
+        $response = $this->elasticSearchClient->getIndex()->request('GET', '/_search', [], $request);
         $timeAfterwards = microtime(true);
 
         $treatedContent = $response->getTreatedContent();
-        $count = $treatedContent['count'];
+        $count = $treatedContent['hits']['total'];
 
         if ($this->logThisQuery === true) {
             $this->logger->log('Count Query Log (' . $this->logMessage . '): ' . $request . ' -- execution time: ' . (($timeAfterwards - $timeBefore) * 1000) . ' ms -- Total Results: ' . $count, LOG_DEBUG);


### PR DESCRIPTION
When "_count" is used, there will be strange results.
E.g. if nothing is found, the method will return 2.
On one match, it returns 1 and on multiple matches > 2,
the count was correct.

**Notice: This is more a hack than a fix.**

This Changes fires a count reqest to the "_search" endpoint of Elasticsearch instead of the "_count" endpoint, results in a correct result.

For more details see #225 