### PR TITLE
BUGFIX: Fulltext query is broken

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -616,7 +616,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
     public function fulltext($searchWord)
     {
         // We automatically enable result highlighting when doing fulltext searches. It is up to the user to use this information or not use it.
-        $this->request->fulltext(json_encode($searchWord));
+        $this->request->fulltext(trim(json_encode($searchWord), '"'));
         $this->request->highlight(150, 2);
 
         return $this;


### PR DESCRIPTION
The fix introduced to escape the query (see #198) also adds quotes around, so it's not
a full text query anymore.

This change trims the output of `json_encode()` to remove the quotes again.

Fixes #197