### PR TITLE
BUGFIX: Fix highlighting with __fulltext* as query_string.fields

### DIFF
--- a/Classes/Driver/Version1/Query/FilteredQuery.php
+++ b/Classes/Driver/Version1/Query/FilteredQuery.php
@@ -57,7 +57,8 @@ class FilteredQuery extends AbstractQuery
     {
         $this->appendAtPath('query.filtered.query.bool.must', [
             'query_string' => [
-                'query' => $searchWord
+                'query' => $searchWord,
+                'fields' => ['__fulltext*']
             ]
         ]);
     }


### PR DESCRIPTION
Elasticsearch highlighting need proper field name match

This adds the necessary field match only to the fulltext() function so that the highlighting works like expected