### PR TITLE
TASK: Catch query errors and return empty result

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -566,7 +566,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
                 $this->result['nodes'] = $this->convertHitsToNodes($this->result['hits']);
             }
         } catch (ApiException $exception) {
-            $this->logger->log('Error while fetching results: ' . $exception->getMessage(), LOG_ERR);
+            $this->logger->logException($exception);
             $this->result['nodes'] = [];
         }
 


### PR DESCRIPTION
Instead of simply ignoring an exception during query execution the
`ElasticSearchQueryBuilder` will now log an exception during `fetch()`
and return an empty result.