### PR TITLE
TASK: Refactor nodeTypeMappingBuilder::convertNodeTypeNameToMappingName

### DIFF
--- a/Classes/Driver/AbstractNodeTypeMappingBuilder.php
+++ b/Classes/Driver/AbstractNodeTypeMappingBuilder.php
@@ -66,7 +66,7 @@ abstract class AbstractNodeTypeMappingBuilder implements NodeTypeMappingBuilderI
      * @param string $nodeTypeName
      * @return string
      */
-    public static function convertNodeTypeNameToMappingName($nodeTypeName)
+    public function convertNodeTypeNameToMappingName($nodeTypeName)
     {
         return str_replace('.', '-', $nodeTypeName);
     }

--- a/Classes/Driver/NodeTypeMappingBuilderInterface.php
+++ b/Classes/Driver/NodeTypeMappingBuilderInterface.php
@@ -27,7 +27,7 @@ interface NodeTypeMappingBuilderInterface
      * @param string $nodeTypeName
      * @return string
      */
-    public static function convertNodeTypeNameToMappingName($nodeTypeName);
+    public function convertNodeTypeNameToMappingName($nodeTypeName);
 
     /**
      * Builds a Mapping Collection from the configured node types

--- a/Classes/Driver/Version1/DocumentDriver.php
+++ b/Classes/Driver/Version1/DocumentDriver.php
@@ -38,11 +38,10 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
      */
     public function delete(NodeInterface $node, $identifier)
     {
-        $nodeTypeMappingBuilder = $this->nodeTypeMappingBuilder;
         return [
             [
                 'delete' => [
-                    '_type' => $nodeTypeMappingBuilder::convertNodeTypeNameToMappingName($node->getNodeType()),
+                    '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($node->getNodeType()),
                     '_id' => $identifier
                 ]
             ]
@@ -54,8 +53,6 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
      */
     public function deleteDuplicateDocumentNotMatchingType(Index $index, $documentIdentifier, NodeType $nodeType)
     {
-        $nodeTypeMappingBuilder = $this->nodeTypeMappingBuilder;
-
         $index->request('DELETE', '/_query', [], json_encode([
             'query' => [
                 'bool' => [
@@ -66,7 +63,7 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
                     ],
                     'must_not' => [
                         'term' => [
-                            '_type' => $nodeTypeMappingBuilder::convertNodeTypeNameToMappingName($nodeType->getName())
+                            '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($nodeType->getName())
                         ]
                     ],
                 ]

--- a/Classes/Driver/Version1/IndexerDriver.php
+++ b/Classes/Driver/Version1/IndexerDriver.php
@@ -108,11 +108,10 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
 
         $this->logger->log(sprintf('NodeIndexer (%s): Updated fulltext index for %s (%s)', $closestFulltextNodeDocumentIdentifier, $closestFulltextNodeContextPath, $closestFulltextNode->getIdentifier()), LOG_DEBUG, null, 'ElasticSearch (CR)');
 
-        $nodeTypeMappingBuilder = $this->nodeTypeMappingBuilder;
         return [
             [
                 'update' => [
-                    '_type' => $nodeTypeMappingBuilder::convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
+                    '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
                     '_id' => $closestFulltextNodeDocumentIdentifier
                 ]
             ],

--- a/Classes/Driver/Version1/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version1/Mapping/NodeTypeMappingBuilder.php
@@ -45,7 +45,7 @@ class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
                 continue;
             }
 
-            $type = $index->findType(self::convertNodeTypeNameToMappingName($nodeTypeName));
+            $type = $index->findType($this->convertNodeTypeNameToMappingName($nodeTypeName));
             $mapping = new Mapping($type);
             $fullConfiguration = $nodeType->getFullConfiguration();
             if (isset($fullConfiguration['search']['elasticSearchMapping'])) {

--- a/Classes/Driver/Version2/DocumentDriver.php
+++ b/Classes/Driver/Version2/DocumentDriver.php
@@ -35,8 +35,6 @@ class DocumentDriver extends Version1\DocumentDriver
      */
     public function deleteDuplicateDocumentNotMatchingType(Index $index, $documentIdentifier, NodeType $nodeType)
     {
-        $nodeTypeMappingBuilder = $this->nodeTypeMappingBuilder;
-
         $result = $index->request('GET', '/_search?scroll=1m', [], json_encode([
             'sort' => ['_doc'],
             'query' => [
@@ -48,7 +46,7 @@ class DocumentDriver extends Version1\DocumentDriver
                     ],
                     'must_not' => [
                         'term' => [
-                            '_type' => $nodeTypeMappingBuilder::convertNodeTypeNameToMappingName($nodeType->getName())
+                            '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($nodeType->getName())
                         ]
                     ]
                 ]

--- a/Classes/Driver/Version2/IndexerDriver.php
+++ b/Classes/Driver/Version2/IndexerDriver.php
@@ -116,11 +116,10 @@ class IndexerDriver extends Version1\IndexerDriver
             $upsertFulltextParts[$node->getIdentifier()] = $fulltextIndexOfNode;
         }
 
-        $nodeTypeMappingBuilder = $this->nodeTypeMappingBuilder;
         return [
             [
                 'update' => [
-                    '_type' => $nodeTypeMappingBuilder::convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
+                    '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
                     '_id' => $closestFulltextNodeDocumentIdentifier
                 ]
             ],

--- a/Classes/Driver/Version5/IndexerDriver.php
+++ b/Classes/Driver/Version5/IndexerDriver.php
@@ -112,7 +112,7 @@ class IndexerDriver extends Version2\IndexerDriver
         return [
             [
                 'update' => [
-                    '_type' => AbstractNodeTypeMappingBuilder::convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
+                    '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($closestFulltextNode->getNodeType()->getName()),
                     '_id' => $closestFulltextNodeDocumentIdentifier
                 ]
             ],

--- a/Classes/Driver/Version5/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version5/Mapping/NodeTypeMappingBuilder.php
@@ -59,7 +59,7 @@ class NodeTypeMappingBuilder extends Version2\Mapping\NodeTypeMappingBuilder
                 continue;
             }
 
-            $type = $index->findType(self::convertNodeTypeNameToMappingName($nodeTypeName));
+            $type = $index->findType($this->convertNodeTypeNameToMappingName($nodeTypeName));
             $mapping = new Mapping($type);
             $fullConfiguration = $nodeType->getFullConfiguration();
             if (isset($fullConfiguration['search']['elasticSearchMapping'])) {

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -190,8 +190,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
             $documentIdentifier = $this->calculateDocumentIdentifier($node, $targetWorkspaceName);
             $nodeType = $node->getNodeType();
 
-            $nodeTypeMappingBuilder = $this->nodeTypeMappingBuilder;
-            $mappingType = $this->getIndex()->findType($nodeTypeMappingBuilder::convertNodeTypeNameToMappingName($nodeType));
+            $mappingType = $this->getIndex()->findType($this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($nodeType));
 
             if ($this->bulkProcessing === false) {
                 // Remove document with the same contextPathHash but different NodeType, required after NodeType change


### PR DESCRIPTION
Refactor the static method nodeTypeMappingBuilder::convertNodeTypeNameToMappingName 
to non-static.
This is needed as the nodeTypeMappingBuilder is now a configurable and injected object
which can be driver specific