### PR TITLE
BUGFIX: Fix highlighting by searching in all fulltext fields

### DIFF
--- a/Classes/Driver/Version2/Query/FilteredQuery.php
+++ b/Classes/Driver/Version2/Query/FilteredQuery.php
@@ -18,4 +18,16 @@ use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version1;
  */
 class FilteredQuery extends Version1\Query\FilteredQuery
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function fulltext($searchWord)
+    {
+        $this->appendAtPath('query.filtered.query.bool.must', [
+            'query_string' => [
+                'query' => $searchWord,
+                'fields' => ['__fulltext*']
+            ]
+        ]);
+    }
 }

--- a/Classes/Driver/Version5/Query/FilteredQuery.php
+++ b/Classes/Driver/Version5/Query/FilteredQuery.php
@@ -27,7 +27,8 @@ class FilteredQuery extends Version1\Query\FilteredQuery
     {
         $this->appendAtPath('query.bool.must', [
             'query_string' => [
-                'query' => $searchWord
+                'query' => $searchWord,
+                'fields' => ['__fulltext*']
             ]
         ]);
     }

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -140,30 +140,37 @@
             'h1':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 20
             'h2':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 12
             'h3':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 10
             'h4':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 5
             'h5':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 3
             'h6':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 2
             'text':
               type: string
               include_in_all: true
+              index: analyzed
               boost: 1
     '_hiddenInIndex':
       search:

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -107,6 +107,45 @@ class ElasticSearchQueryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function fullTextSearchReturnsTheDocumentNode() {
+        /** @var ElasticSearchQueryResult $result */
+        $result = $this->getQueryBuilder()
+            ->fulltext('circum*')
+            ->execute();
+
+        $this->assertEquals(1, $result->count());
+
+        /** @var NodeInterface $node */
+        $node = $result->current();
+        $this->assertEquals('TYPO3.Neos.NodeTypes:Page', $node->getNodeType()->getName());
+        $this->assertEquals('test-node-1', $node->getName());
+    }
+
+
+    /**
+     * @test
+     */
+    public function fullTextHighlighting() {
+        $queryBuilder = $this->getQueryBuilder();
+
+        /** @var NodeInterface $resultNode */
+        $resultNode = $queryBuilder
+            ->fulltext('whistles')
+            ->log($this->getLogMessagePrefix(__METHOD__))
+            ->execute()
+            ->current();
+        $searchHitForNode = $queryBuilder->getFullElasticSearchHitForNode($resultNode);
+        $highlightedText = current($searchHitForNode['highlight']['__fulltext.text']);
+
+        $expected = 'A Scout smiles and <em>whistles</em> under all circumstances.';
+
+        $this->assertEquals($expected, $highlightedText);
+    }
+
+
+    /**
+     * @test
+     */
     public function elasticSearchQueryBuilderStartsClean()
     {
         /** @var ElasticSearchQueryBuilder $query */

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -122,7 +122,6 @@ class ElasticSearchQueryTest extends FunctionalTestCase
         $this->assertEquals('test-node-1', $node->getName());
     }
 
-
     /**
      * @test
      */
@@ -143,7 +142,6 @@ class ElasticSearchQueryTest extends FunctionalTestCase
 
         $this->assertEquals($expected, $highlightedText);
     }
-
 
     /**
      * @test

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -107,7 +107,8 @@ class ElasticSearchQueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function fullTextSearchReturnsTheDocumentNode() {
+    public function fullTextSearchReturnsTheDocumentNode()
+    {
         /** @var ElasticSearchQueryResult $result */
         $result = $this->getQueryBuilder()
             ->fulltext('circum*')
@@ -125,7 +126,8 @@ class ElasticSearchQueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function fullTextHighlighting() {
+    public function fullTextHighlighting()
+    {
         $queryBuilder = $this->getQueryBuilder();
 
         /** @var NodeInterface $resultNode */


### PR DESCRIPTION
Only fields are highlighted which are searched on.
This changes the search from _all to the fullText fields.

Fix #232