### PR TITLE
BUGFIX: Make sure __fulltextParts and __fulltext are of type map

### DIFF
--- a/Classes/Driver/Version5/IndexerDriver.php
+++ b/Classes/Driver/Version5/IndexerDriver.php
@@ -47,8 +47,8 @@ class IndexerDriver extends Version2\IndexerDriver
                     'script' => [
                         'lang' => 'painless',
                         'inline' => '
-                            HashMap fulltext = (ctx._source.containsKey("__fulltext") ? ctx._source.__fulltext : new HashMap());
-                            HashMap fulltextParts = (ctx._source.containsKey("__fulltextParts") ? ctx._source.__fulltextParts : new HashMap());
+                            HashMap fulltext = (ctx._source.containsKey("__fulltext") && ctx._source.__fulltext instanceof Map ? ctx._source.__fulltext : new HashMap());
+                            HashMap fulltextParts = (ctx._source.containsKey("__fulltextParts") && ctx._source.__fulltextParts instanceof Map ? ctx._source.__fulltextParts : new HashMap());
                             ctx._source = params.newData;
                             ctx._source.__fulltext = fulltext;
                             ctx._source.__fulltextParts = fulltextParts',
@@ -123,7 +123,7 @@ class IndexerDriver extends Version2\IndexerDriver
                     'lang' => 'painless',
                     'inline' => '
                         ctx._source.__fulltext = new HashMap();
-                        if (!ctx._source.containsKey("__fulltextParts")) {
+                        if (!ctx._source.containsKey("__fulltextParts") || !(ctx._source.__fulltextParts instanceof Map)) {
                             ctx._source.__fulltextParts = new HashMap();
                         }
 


### PR DESCRIPTION
For yet unknown reasons, __fulltextParts and __fulltext are initialized
as type ArrayList instead of HashMap and operations like containsKey()
fail. The painless script now checks the type and re-initializes it
if it is not a HashMap