### PR TITLE
FEATURE: Add a method to calculate the cache lifetime of all nodes

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -824,7 +824,9 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         $minTimestamps = array_filter([
             $convertDateResultToTimestamp(Arrays::getValueByPath($result, 'aggregations.minHiddenBeforeDateTime')),
             $convertDateResultToTimestamp(Arrays::getValueByPath($result, 'aggregations.minHiddenAfterDateTime'))
-        ]);
+        ], function ($value, $_) {
+            return $value != 0 || $value > $this->now->getTimestamp();
+        }, ARRAY_FILTER_USE_BOTH);
 
         if (empty($minTimestamps)) {
             return 0;
@@ -832,7 +834,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
 
         $minTimestamp = min($minTimestamps);
 
-        return $minTimestamp > $this->now->getTimestamp() ? $minTimestamp - $this->now->getTimestamp() : 0;
+        return $minTimestamp - $this->now->getTimestamp();
     }
 
     /**

--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -22,6 +22,8 @@ use Neos\ContentRepository\Search\Search\QueryBuilderInterface;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Utility\Now;
+use Neos\Utility\Arrays;
 
 /**
  * Query Builder for ElasticSearch Queries
@@ -72,6 +74,12 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      * @var integer
      */
     protected $from;
+
+    /**
+     * @Flow\Inject(lazy=false)
+     * @var Now
+     */
+    protected $now;
 
     /**
      * This (internal) array stores, for the last search request, a mapping from Node Identifiers
@@ -181,7 +189,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      */
     public function limit($limit)
     {
-        if (!$limit) {
+        if ($limit === null) {
             return $this;
         }
 
@@ -415,7 +423,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      * @return $this
      * @throws QueryBuildingException
      */
-    public function aggregation($name, array $aggregationDefinition, $parentPath = '')
+    public function aggregation(string $name, array $aggregationDefinition, $parentPath = ''): ElasticSearchQueryBuilder
     {
         $this->request->aggregation($name, $aggregationDefinition, $parentPath);
 
@@ -763,6 +771,68 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         $this->elasticSearchHitsIndexedByNodeFromLastRequest = $elasticSearchHitPerNode;
 
         return array_values($nodes);
+    }
+
+    /**
+     * This method will get the minimum of all allowed cache lifetimes for the
+     * nodes that would result from the current defined query. This means it will evaluate to the nearest future value of the
+     * hiddenBeforeDateTime or hiddenAfterDateTime properties of all nodes in the result.
+     *
+     * @return int
+     * @throws QueryBuildingException
+     * @throws \Flowpack\ElasticSearch\Exception
+     */
+    public function cacheLifetime(): int
+    {
+        $this->request->aggregation('minHiddenBeforeDateTime', [
+            'min' => [
+                'field' => '_hiddenBeforeDateTime'
+            ]
+        ]);
+
+        $this->request->aggregation('minHiddenAfterDateTime', [
+            'min' => [
+                'field' => '_hiddenAfterDateTime'
+            ]
+        ]);
+
+        $this->request->size(0);
+
+        $requestArray = $this->request->toArray();
+
+        $mustNot = Arrays::getValueByPath($requestArray, 'query.bool.filter.bool.must_not');
+
+        /* Remove exclusion of not yet visible nodes
+        - range:
+          _hiddenBeforeDateTime:
+            gt: now
+        */
+        unset($mustNot[1]);
+
+        $requestArray = Arrays::setValueByPath($requestArray, 'query.bool.filter.bool.must_not', array_values($mustNot));
+        $response = $this->elasticSearchClient->getIndex()->request('GET', '/_search', [], $requestArray);
+
+        $result = $response->getTreatedContent();
+
+        $convertDateResultToTimestamp = function (array $dateResult): int {
+            if (!isset($dateResult['value_as_string'])) {
+                return 0;
+            }
+            return (new \DateTime($dateResult['value_as_string']))->getTimestamp();
+        };
+
+        $minTimestamps = array_filter([
+            $convertDateResultToTimestamp(Arrays::getValueByPath($result, 'aggregations.minHiddenBeforeDateTime')),
+            $convertDateResultToTimestamp(Arrays::getValueByPath($result, 'aggregations.minHiddenAfterDateTime'))
+        ]);
+
+        if (empty($minTimestamps)) {
+            return 0;
+        }
+
+        $minTimestamp = min($minTimestamps);
+
+        return $minTimestamp > $this->now->getTimestamp() ? $minTimestamp - $this->now->getTimestamp() : 0;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ of an array or a string. Check the documentation \Neos\Utility\Arrays::getValueB
 
 **Important notice**
 
-The ViewHelper GetHitArrayForNode will return the raw hit result array. The path poperty allows you to access some
+The ViewHelper GetHitArrayForNode will return the raw hit result array. The path property allows you to access some
 specific data like the the sort data. If there is only one value for your path the value will be returned.
 If there is more data the full array will be returned by GetHitArrayForNode-VH. So you might have to use the
 ForViewHelper to access your sort values.
@@ -472,6 +472,29 @@ suggestionsQueryDefinition = Neos.Fusion:RawArray {
 }
 suggestions = ${Search.query(site)...suggestions('my_suggestions', this.suggestionsQueryDefinition)}
 ```
+
+## Calculate the maximum cache time
+
+In order to set the maximum cache time of a fusion prototype that renders nodes fetched by `Search()`,
+the nearest future value of the hiddenBeforeDateTime or hiddenAfterDateTime properties of all nodes in the result needs to be calculated.
+
+	prototype(Acme.Blog:Listing) < prototype(Neos.Fusion:Collection) {
+		@context.searchQuery = ${Search.query(site).nodeType('Acme.Blog:Post')}
+	
+	    collection = ${searchQuery.execute()}
+	    itemName = 'node'
+	    itemRenderer = Acme.Blog:Post
+	    
+	     @cache {
+        	mode = 'cached'
+			maximumLifetime = ${searchQuery.cacheLifetime()}
+			
+        	entryTags {
+          	map = ${'NodeType_Acme.Blog:Post'}
+        	}
+    	}
+	}
+
 
 ## Advanced: Configuration of Indexing
 


### PR DESCRIPTION
In order to calculate the maximum cache time of a rendered collection of fetched nodes, we need a method similar to the `.cacheLifetime()` flowQuery method.