### PR TITLE
TASK: Extract result evaluation

### DIFF
--- a/Classes/Dto/SearchResult.php
+++ b/Classes/Dto/SearchResult.php
@@ -1,0 +1,47 @@
+<?php
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Dto;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class SearchResult
+{
+    /**
+     * @var int
+     */
+    protected $total;
+
+    /**
+     * @var array
+     */
+    protected $hits;
+
+    public function __construct(array $hits, int $total)
+    {
+        $this->hits = $hits;
+        $this->total = $total;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHits(): array
+    {
+        return $this->hits;
+    }
+}

--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -562,15 +562,12 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
             $searchResult = $this->evaluateResult($this->result);
 
             $this->result['nodes'] = [];
-            if ($this->logThisQuery === true) {
-                $this->logger->log(sprintf('Query Log (%s): %s -- execution time: %s ms -- Limit: %s -- Number of results returned: %s -- Total Results: %s',
-                    $this->logMessage, $request, (($timeAfterwards - $timeBefore) * 1000), $this->limit, count($searchResult->getHits()), $searchResult->getTotal()), LOG_DEBUG);
-            }
+
+            $this->logThisQuery && $this->logger->log(sprintf('Query Log (%s): %s -- execution time: %s ms -- Limit: %s -- Number of results returned: %s -- Total Results: %s', $this->logMessage, $request, (($timeAfterwards - $timeBefore) * 1000), $this->limit, count($searchResult->getHits()), $searchResult->getTotal()), LOG_DEBUG);
 
             if (count($searchResult->getHits()) > 0) {
                 $this->result['nodes'] = $this->convertHitsToNodes($searchResult->getHits());
             }
-
         } catch (ApiException $exception) {
             $this->logger->logException($exception);
             $this->result['nodes'] = [];
@@ -623,9 +620,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
         $treatedContent = $response->getTreatedContent();
         $count = $treatedContent['count'];
 
-        if ($this->logThisQuery === true) {
-            $this->logger->log('Count Query Log (' . $this->logMessage . '): ' . $request . ' -- execution time: ' . (($timeAfterwards - $timeBefore) * 1000) . ' ms -- Total Results: ' . $count, LOG_DEBUG);
-        }
+        $this->logThisQuery && $this->logger->log('Count Query Log (' . $this->logMessage . '): ' . $request . ' -- execution time: ' . (($timeAfterwards - $timeBefore) * 1000) . ' ms -- Total Results: ' . $count, LOG_DEBUG);
 
         return $count;
     }
@@ -768,9 +763,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
             }
         }
 
-        if ($this->logThisQuery === true) {
-            $this->logger->log('Returned nodes (' . $this->logMessage . '): ' . count($nodes), LOG_DEBUG);
-        }
+        $this->logThisQuery && $this->logger->log('Returned nodes (' . $this->logMessage . '): ' . count($nodes), LOG_DEBUG);
 
         $this->elasticSearchHitsIndexedByNodeFromLastRequest = $elasticSearchHitPerNode;
 


### PR DESCRIPTION
Result handling in the ES adapter is a bit messy. 
In order to adjust the result evaluation (where the actual hits are coming from), this code is extracted into a separate method which returns a result dto. 