### PR TITLE
TASK: Configure ESQueryBuilder as implementation of the QueryBuilderInterface

### DIFF
--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,3 +1,6 @@
+Neos\ContentRepository\Search\Search\QueryBuilderInterface:
+  className: Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder
+
 Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\QueryInterface:
   scope: prototype
   factoryObjectName: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Factory\QueryFactory'


### PR DESCRIPTION
When you try to extend the ElasticSearchQueryBuilder and with this adding a second class implementing
the QueryBuilderInterface, the ObjectManager is not able to automatically select the implementing class
any more. This adds this missing configuration