### PR TITLE
TASK: Add important note for the suggestion on 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ _Currently the Driver interfaces are not marked as API, and can be changed to ad
 **Note:** When using Elasticsearch 5.x changes to the types may need to be done in your mapping.
 More information on the [mapping in ElasticSearch 5.x](Documentation/ElasticMapping-5.x.md).
 
+**IMPORTATN:** When using Elasticsearch 5.x the suggest and autocomplete feature is actually not working.
+
 ### Elasticsearch Configuration file elasticsearch.yml
 
 There is a need, depending on your version of Elasticsearch, to add specific configuration to your

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _Currently the Driver interfaces are not marked as API, and can be changed to ad
 **Note:** When using Elasticsearch 5.x changes to the types may need to be done in your mapping.
 More information on the [mapping in ElasticSearch 5.x](Documentation/ElasticMapping-5.x.md).
 
-**IMPORTATN:** When using Elasticsearch 5.x the suggest and autocomplete feature is actually not working.
+**IMPORTANT:** When using Elasticsearch 5.x the suggest and autocomplete feature is actually not working.
 
 ### Elasticsearch Configuration file elasticsearch.yml
 


### PR DESCRIPTION
I think it is important to know,  that when using Elasticsearch 5.x the suggest and autocomplete feature is actually not working.

I also only read the docs before using the package and thought awesome that this is there.
But to prevent more slack messages on that topic, I think a mention in the docs is worth it until it is fixed/reimplemented.