### PR TITLE
BUGFIX: fix logic of getting __path from result

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -733,7 +733,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
          * we might be able to use https://github.com/elasticsearch/elasticsearch/issues/3300 as soon as it is merged.
          */
         foreach ($hits['hits'] as $hit) {
-            $nodePath = $hit[isset($hit['fields']) ? 'fields' : '_source']['__path'];
+            $nodePath = $hit[isset($hit['fields']['__path']) ? 'fields' : '_source']['__path'];
             if (is_array($nodePath)) {
                 $nodePath = current($nodePath);
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/837032/50042626-bf788b80-0076-11e9-8044-f50941a5844d.png)


Sometimes certain requests return some fields under `fields` path. In that case the current logic tries to search for `__path` under `['fields]['__path']` and obviouls fails with ` Undefined index: __path`.

The PR attempts to fix it.
It should later be upmerged to 4.x and master.