### PR TITLE
BUGFIX: fix upmerge gone wrong

### DIFF
--- a/Classes/Driver/QueryInterface.php
+++ b/Classes/Driver/QueryInterface.php
@@ -69,13 +69,14 @@ interface QueryInterface
     public function from($size);
 
     /**
-     * Match the searchword against the fulltext index
+     * Match the search word against the fulltext index
      *
      * @param string $searchWord
+     * @param array $options Options to configure the query_string
      * @return void
      * @api
      */
-    public function fulltext($searchWord);
+    public function fulltext(string $searchWord, array $options = []);
 
     /**
      * Configure Result Highlighting. Only makes sense in combination with fulltext(). By default, highlighting is enabled.

--- a/Classes/Driver/Version1/Query/FilteredQuery.php
+++ b/Classes/Driver/Version1/Query/FilteredQuery.php
@@ -53,12 +53,10 @@ class FilteredQuery extends AbstractQuery
     /**
      * {@inheritdoc}
      */
-    public function fulltext($searchWord)
+    public function fulltext(string $searchWord, array $options = [])
     {
         $this->appendAtPath('query.filtered.query.bool.must', [
-            'query_string' => [
-                'query' => $searchWord
-            ]
+            'query_string' => array_merge($options, ['query' => $searchWord])
         ]);
     }
 

--- a/Classes/Driver/Version5/Query/FilteredQuery.php
+++ b/Classes/Driver/Version5/Query/FilteredQuery.php
@@ -23,12 +23,10 @@ class FilteredQuery extends Version1\Query\FilteredQuery
     /**
      * {@inheritdoc}
      */
-    public function fulltext($searchWord)
+    public function fulltext(string $searchWord, array $options = [])
     {
         $this->appendAtPath('query.bool.must', [
-            'query_string' => [
-                'query' => $searchWord
-            ]
+            'query_string' => array_merge($options, ['query' => $searchWord])
         ]);
     }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Neos Elasticsearch Adapter
 
-This project connects the Neos Content Repository (TYPO3CR) to Elasticsearch; enabling two
+This project connects the Neos Content Repository to Elasticsearch; enabling two
 main functionalities:
 
 * finding Nodes in Fusion / Eel by arbitrary queries
@@ -128,8 +128,8 @@ search underneath the current site node (like in the example above).
 
 Furthermore, the following operators are supported:
 
-* `nodeType("Your.Node:Type")`
-* `exactMatch('propertyName', value)`; supports simple types: `exactMatch('tag', 'foo')`, or node references: `exactMatch('author', authorNode)`
+* `nodeType('Your.Node:Type')`
+* `exactMatch('propertyName', value)` -- supports simple types: `exactMatch('tag', 'foo')`, or node references: `exactMatch('author', authorNode)`
 * `greaterThan('propertyName', value)` -- range filter with property values greater than the given value
 * `greaterThanOrEqual('propertyName', value)` -- range filter with property values greater than or equal to the given value
 * `lessThan('propertyName', value)` -- range filter with property values less than the given value
@@ -138,7 +138,7 @@ Furthermore, the following operators are supported:
    will first sort by tag ascending, and then by date descending.
 * `limit(5)` -- only return five results. If not specified, the default limit by Elasticsearch applies (which is at 10 by default)
 * `from(5)` -- return the results starting from the 6th one
-* `fulltext(...)` -- do a query_string query on the Fulltext Index
+* `fulltext('searchWord', options)` -- do a query_string query on the Fulltext index using the searchword and additional [options](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-query-string-query.html) to the query_string
 
 Furthermore, there is a more low-level operator which can be used to add arbitrary Elasticsearch filters:
 


### PR DESCRIPTION
I still struggle to understand how it happened.
As I understand, it had to be so that changes in 3.0 branch had to be more recent than in 4.0. But how then would you explain things like reappearing of `TYPO3CR` in the readme?!

Fixes: #291