### PR TITLE
TASK: Modified Flowpack.ElasticSearch requirement to include 3.X (Backport of #299)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.2",
         "ext-json": "*",
 
-        "flowpack/elasticsearch": "^2.0 || dev-master",
+        "flowpack/elasticsearch": "^2.0 || ^3.0 || dev-master",
         "neos/content-repository": "^3.3 || ^4.0 || dev-master",
         "neos/content-repository-search": "^3.0 || ^4.0 || dev-master",
         "neos/eel": "^4.3 || ^5.0 || dev-master",


### PR DESCRIPTION
Version 3.0.0 of Flowpack.ElasticSearch was released some weeks ago which has support for ElasticSearch 5 and 6. The Flowpack.ElasticSearch.ContentreposiotryAdaptor however requires 2.x or dev-master. This PR modifies contentrepositoryadaptor to support version 3.x of Flowpack.ElasticSearch. Currently no installable combination working for Elasticsearch 5.x is possible.

Related to #299