### PR TITLE
BUGFIX: restructure invalid elasticsearch scroll request

### DIFF
--- a/Classes/Driver/Version5/DocumentDriver.php
+++ b/Classes/Driver/Version5/DocumentDriver.php
@@ -87,7 +87,10 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
         while (isset($treatedContent['hits']['hits']) && $treatedContent['hits']['hits'] !== []) {
             $hits = $treatedContent['hits']['hits'];
             $bulkRequest = array_merge($bulkRequest, array_map($mapHitToDeleteRequest, $hits));
-            $result = $index->request('GET', '/_search/scroll?scroll=1m', [], $scrollId, false);
+            $result = $index->request('GET', '/_search/scroll', [], json_encode([
+                'scroll' => '1m',
+                'scroll_id' => $scrollId
+            ]));
             $treatedContent = $result->getTreatedContent();
         }
         $this->logger->log(sprintf('NodeIndexer: Check duplicate nodes for %s (%s), found %d document(s)', $documentIdentifier, $nodeType->getName(), count($bulkRequest)), LOG_DEBUG, null, 'ElasticSearch (CR)');


### PR DESCRIPTION
This fixes an error thrown when changing the node-type of a document node (see issue #300 ).
To be honest i am not 100% sure what that code in DocumentDriver.php actually does but it seems the request to the elasticsearch instance had two errors:
-  It did not include the indexname (hence the last parameter was "false")
-  It had a wrong structure so elasticsearch 5.6 threw an error

It would be great if someone could look at it and verify if my fix brakes the intended behaviour. I did only test if the error disappeared.