### PR TITLE
BUGFIX: Move scroll parameter to POST body in Version5/DocumentDriver

### DIFF
--- a/Classes/Driver/Version5/DocumentDriver.php
+++ b/Classes/Driver/Version5/DocumentDriver.php
@@ -88,7 +88,10 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
         while (isset($treatedContent['hits']['hits']) && $treatedContent['hits']['hits'] !== []) {
             $hits = $treatedContent['hits']['hits'];
             $bulkRequest = array_merge($bulkRequest, array_map($mapHitToDeleteRequest, $hits));
-            $result = $index->request('GET', '/_search/scroll?scroll=1m', [], $scrollId, false);
+            $result = $index->request('POST', '/_search/scroll', [], json_encode([
+                'scroll'    => '1m',
+                'scroll_id' => $scrollId,
+            ]), false);
             $treatedContent = $result->getTreatedContent();
         }
         $this->logger->debug(sprintf('NodeIndexer: Check duplicate nodes for %s (%s), found %d document(s)', $documentIdentifier, $nodeType->getName(), count($bulkRequest)), LogEnvironment::fromMethodName(__METHOD__));


### PR DESCRIPTION
After switching from ES 2.3 to ES 5.6.16 an error occured during changing the DocumentType in the neos backend:
```
Elasticsearch request failed. [GET http://elasticsearch:9200//_search/scroll?scroll=1m]: Array ( [root_cause] => Array ( [0] => Array ( [type] => illegal_argument_exception [reason] => request [//_search/scroll] contains unrecognized parameter: [scroll] ) ) [type] => illegal_argument_exception [reason] => request [//_search/scroll] contains unrecognized parameter: [scroll] ) ; Response body: {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [//_search/scroll] contains unrecognized parameter: [scroll]"}],"type":"illegal_argument_exception","reason":"request [//_search/scroll] contains unrecognized parameter: [scroll]"},"status":400} Request data: DnF1ZXJ5VGhlbkZldGNoBQAAAAAACARZFkpkMjNTNHJEU1hDbnhrdjY5c3NjSFEAAAAAAAgEWhZKZDIzUzRyRFNYQ254a3Y2OXNzY0hRAAAAAAAIBFsWSmQyM1M0ckRTWENueGt2Njlzc2NIUQAAAAAACARcFkpkMjNTNHJEU1hDbnhrdjY5c3NjSFEAAAAAAAgEXRZKZDIzUzRyRFNYQ254a3Y2OXNzY0hR
```

I'm not that much into ES queries, but the ES 5.6. documentation suggested to use a query like this:
```
curl -X POST "localhost:9200/_search/scroll?pretty" -H 'Content-Type: application/json' -d'
{
    "scroll" : "1m", 
    "scroll_id" : "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==" 
}
'
```
see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-scroll.html

This PR moves the scroll GET query parameter into a POST parameter. After this change, the error doesn't occur.

Note: The docs for ES 2.3: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/search-request-scroll.html