### PR TITLE
BUGFIX: Do not escape unicode characters for fulltext search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - cd ..
   - git clone https://github.com/neos/neos-base-distribution.git -b ${NEOS_TARGET_VERSION}
   - cd neos-base-distribution
+  - composer remove --no-update --no-interaction neos/site-kickstarter
   - composer require --no-update --no-interaction flowpack/elasticsearch-contentrepositoryadaptor:dev-master
 install:
   - composer install --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       env: ES=5
 
 before_install:
-  - export NEOS_TARGET_VERSION=4.0
+  - export NEOS_TARGET_VERSION=4.3
   - cd ..
   - if [ "$ES" = 5 ]; then wget --no-check-certificate https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.15.zip && unzip elasticsearch-5.6.15.zip && mv elasticsearch-5.6.15 elasticsearch; fi
   - cd elasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - git clone https://github.com/neos/neos-base-distribution.git -b ${NEOS_TARGET_VERSION}
   - cd neos-base-distribution
   - composer remove --no-update --no-interaction neos/site-kickstarter
-  - composer require --no-update --no-interaction flowpack/elasticsearch-contentrepositoryadaptor:dev-master
+  - composer require --no-update --no-interaction flowpack/elasticsearch-contentrepositoryadaptor:^5.0
 install:
   - composer install --no-interaction
   - cd ..

--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel;
@@ -669,7 +668,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
     public function fulltext($searchWord, array $options = [])
     {
         // We automatically enable result highlighting when doing fulltext searches. It is up to the user to use this information or not use it.
-        $this->request->fulltext(trim(json_encode($searchWord), '"'), $options);
+        $this->request->fulltext(trim(json_encode($searchWord, JSON_UNESCAPED_UNICODE), '"'), $options);
         $this->request->highlight(150, 2);
 
         return $this;


### PR DESCRIPTION
For details see: https://discuss.neos.io/t/elasticsearch-special-chars-umlauts/4869