### PR TITLE
WIP: !!! TASK: Rename fields to beats convention

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -557,7 +557,6 @@ class NodeIndexCommandController extends CommandController
             /** @var Mapping $mapping */
             $mapping->apply();
         }
-        $this->logger->info('+ Updated Mapping.', LogEnvironment::fromMethodName(__METHOD__));
     }
 
     private function outputMemoryUsage(): void

--- a/Classes/Command/SearchCommandController.php
+++ b/Classes/Command/SearchCommandController.php
@@ -113,7 +113,7 @@ class SearchCommandController extends CommandController
 
         $queryBuilder = new ElasticSearchQueryBuilder();
         $queryBuilder->query($context->getRootNode());
-        $queryBuilder->exactMatch('__identifier', $identifier);
+        $queryBuilder->exactMatch('neos_node_identifier', $identifier);
 
         $queryBuilder->getRequest()->setValueByPath('_source', []);
 

--- a/Classes/Driver/AbstractQuery.php
+++ b/Classes/Driver/AbstractQuery.php
@@ -188,7 +188,7 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
         } else {
             $this->request['highlight'] = [
                 'fields' => [
-                    '__fulltext*' => [
+                    'neos_fulltext*' => [
                         'fragment_size' => $fragmentSize,
                         'no_match_size' => $fragmentSize,
                         'number_of_fragments' => $fragmentCount

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -279,7 +279,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
 
             $documentData = $document->getData();
             if ($targetWorkspaceName !== null) {
-                $documentData['__workspace'] = $targetWorkspaceName;
+                $documentData['neos_workspace'] = $targetWorkspaceName;
             }
 
             $this->toBulkRequest($node, $this->indexerDriver->document($this->getIndexName(), $node, $document, $documentData));

--- a/Configuration/NodeTypes.Override.Document.yaml
+++ b/Configuration/NodeTypes.Override.Document.yaml
@@ -10,13 +10,13 @@
     title:
       search:
         fulltextExtractor: ${Indexing.extractInto('h1', value)}
-    '__fulltextParts':
+    'neos_fulltext_parts':
       search:
         elasticSearchMapping:
           type: object
           enabled: false
         indexing: ''
-    '__fulltext':
+    'neos_fulltext':
       search:
         indexing: ''
         elasticSearchMapping:
@@ -36,6 +36,6 @@
               type: text
             'text':
               type: text
-    '_hiddenInIndex':
+    'neos_hidden_in_index':
       search:
         indexing: '${node.hiddenInIndex}'

--- a/Configuration/NodeTypes.Override.Document.yaml
+++ b/Configuration/NodeTypes.Override.Document.yaml
@@ -39,3 +39,8 @@
     'neos_hidden_in_index':
       search:
         indexing: '${node.hiddenInIndex}'
+
+    # deliberately don't map or index this
+    '_hiddenInIndex':
+      search:
+        indexing: false

--- a/Configuration/NodeTypes.Override.Hidable.yaml
+++ b/Configuration/NodeTypes.Override.Hidable.yaml
@@ -1,5 +1,5 @@
 'Neos.Neos:Hidable':
   properties:
-    '_hidden':
+    'neos_hidden':
       search:
         indexing: '${node.hidden}'

--- a/Configuration/NodeTypes.Override.Node.yaml
+++ b/Configuration/NodeTypes.Override.Node.yaml
@@ -3,64 +3,64 @@
     fulltext:
       enable: true
   properties:
-    '__identifier':
+    'neos_node_identifier':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${node.identifier}'
 
-    '__workspace':
+    'neos.workspace':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${node.context.workspace.name}'
 
-    '__path':
+    'neos.path':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${node.path}'
 
-    '__parentPath':
+    'neos.parent_path':
       search:
         elasticSearchMapping:
           type: keyword
         # we index *all* parent paths as separate tokens to allow for efficient searching without a prefix query
         indexing: '${Indexing.buildAllPathPrefixes(node.parentPath)}'
 
-    '__sortIndex':
+    'neos.sort_index':
       search:
         elasticSearchMapping:
           type: integer
         indexing: '${node.index}'
 
-    '_removed':
+    'neos.removed':
       search:
         elasticSearchMapping: '' # deliberately don't map or index this
         indexing: ''
 
     # we index the node type INCLUDING ALL SUPERTYPES
-    '__typeAndSupertypes':
+    'neos.type_and_supertypes':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${Indexing.extractNodeTypeNamesAndSupertypes(node.nodeType)}'
 
-    '_lastModificationDateTime':
+    'neos.last_modification_date_time':
       search:
         elasticSearchMapping:
           type: date
           format: 'date_time_no_millis'
         indexing: '${(node.lastModificationDateTime ? Date.format(node.lastModificationDateTime, "Y-m-d\TH:i:sP") : null)}'
 
-    '_lastPublicationDateTime':
+    'neos.last_publication_date_time':
       search:
         elasticSearchMapping:
           type: date
           format: 'date_time_no_millis'
         indexing: '${(node.lastPublicationDateTime ? Date.format(node.lastPublicationDateTime, "Y-m-d\TH:i:sP") : null)}'
 
-    '_creationDateTime':
+    'neos.creation_date_time':
       search:
         elasticSearchMapping:
           type: date

--- a/Configuration/NodeTypes.Override.Node.yaml
+++ b/Configuration/NodeTypes.Override.Node.yaml
@@ -1,4 +1,4 @@
-'neos_Neos:Node': &node
+'Neos.Neos:Node': &node
   search:
     fulltext:
       enable: true
@@ -34,11 +34,6 @@
           type: integer
         indexing: '${node.index}'
 
-    'neos_removed':
-      search:
-        elasticSearchMapping: '' # deliberately don't map or index this
-        indexing: ''
-
     # we index the node type INCLUDING ALL SUPERTYPES
     'neos_type_and_supertypes':
       search:
@@ -66,5 +61,37 @@
           type: date
           format: 'date_time_no_millis'
         indexing: '${(node.creationDateTime ? Date.format(node.creationDateTime, "Y-m-d\TH:i:sP") : null)}'
+
+    # deliberately don't map or index this
+    '_removed':
+      search:
+        indexing: false
+    '_creationDateTime':
+      search:
+        indexing: false
+    '_lastModificationDateTime':
+      search:
+        indexing: false
+    '_lastPublicationDateTime':
+      search:
+        indexing: false
+    '_hiddenBeforeDateTime':
+      search:
+        indexing: false
+    '_hiddenAfterDateTime':
+      search:
+        indexing: false
+    '_path':
+      search:
+        indexing: false
+    '_nodeType':
+      search:
+        indexing: false
+    '_name':
+      search:
+        indexing: false
+    '_hidden':
+      search:
+        indexing: false
 
 'unstructured': *node

--- a/Configuration/NodeTypes.Override.Node.yaml
+++ b/Configuration/NodeTypes.Override.Node.yaml
@@ -1,4 +1,4 @@
-'Neos.Neos:Node': &node
+'neos_Neos:Node': &node
   search:
     fulltext:
       enable: true
@@ -9,58 +9,58 @@
           type: keyword
         indexing: '${node.identifier}'
 
-    'neos.workspace':
+    'neos_workspace':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${node.context.workspace.name}'
 
-    'neos.path':
+    'neos_path':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${node.path}'
 
-    'neos.parent_path':
+    'neos_parent_path':
       search:
         elasticSearchMapping:
           type: keyword
         # we index *all* parent paths as separate tokens to allow for efficient searching without a prefix query
         indexing: '${Indexing.buildAllPathPrefixes(node.parentPath)}'
 
-    'neos.sort_index':
+    'neos_sort_index':
       search:
         elasticSearchMapping:
           type: integer
         indexing: '${node.index}'
 
-    'neos.removed':
+    'neos_removed':
       search:
         elasticSearchMapping: '' # deliberately don't map or index this
         indexing: ''
 
     # we index the node type INCLUDING ALL SUPERTYPES
-    'neos.type_and_supertypes':
+    'neos_type_and_supertypes':
       search:
         elasticSearchMapping:
           type: keyword
         indexing: '${Indexing.extractNodeTypeNamesAndSupertypes(node.nodeType)}'
 
-    'neos.last_modification_date_time':
+    'neos_last_modification_date_time':
       search:
         elasticSearchMapping:
           type: date
           format: 'date_time_no_millis'
         indexing: '${(node.lastModificationDateTime ? Date.format(node.lastModificationDateTime, "Y-m-d\TH:i:sP") : null)}'
 
-    'neos.last_publication_date_time':
+    'neos_last_publication_date_time':
       search:
         elasticSearchMapping:
           type: date
           format: 'date_time_no_millis'
         indexing: '${(node.lastPublicationDateTime ? Date.format(node.lastPublicationDateTime, "Y-m-d\TH:i:sP") : null)}'
 
-    'neos.creation_date_time':
+    'neos_creation_date_time':
       search:
         elasticSearchMapping:
           type: date

--- a/Configuration/NodeTypes.Override.Timable.yaml
+++ b/Configuration/NodeTypes.Override.Timable.yaml
@@ -1,13 +1,13 @@
 'Neos.Neos:Timable':
   properties:
-    '_hiddenBeforeDateTime':
+    'neos_hidden_before_datetime':
       search:
         elasticSearchMapping:
           type: date
           format: 'date_time_no_millis'
         indexing: '${(node.hiddenBeforeDateTime ? Date.format(node.hiddenBeforeDateTime, "Y-m-d\TH:i:sP") : null)}'
 
-    '_hiddenAfterDateTime':
+    'neos_hidden_after_datetime':
       search:
         elasticSearchMapping:
           type: date

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -30,15 +30,15 @@ Flowpack:
                           should: []
                           must_not:
                             - term:
-                                _hidden: true
+                                neos_hidden: true
                             - range:
-                                _hiddenBeforeDateTime:
+                                neos_hidden_before_datetime:
                                   gt: now
                             - range:
-                                _hiddenAfterDateTime:
+                                neos_hidden_after_datetime:
                                   lt: now
                   _source:
-                    - '__path'
+                    - 'neos_path'
 
                 unsupportedFieldsInCountRequest:
                   - '_source'
@@ -56,13 +56,13 @@ Flowpack:
                 queryStringParameters:
                   default_operator: or
                   fields:
-                    - __fulltext.h1^20
-                    - __fulltext.h2^12
-                    - __fulltext.h3^10
-                    - __fulltext.h4^5
-                    - __fulltext.h5^3
-                    - __fulltext.h6^2
-                    - __fulltext.text^1
+                    - neos_fulltext.h1^20
+                    - neos_fulltext.h2^12
+                    - neos_fulltext.h3^10
+                    - neos_fulltext.h4^5
+                    - neos_fulltext.h5^3
+                    - neos_fulltext.h6^2
+                    - neos_fulltext.text^1
 
             document:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\DocumentDriver'

--- a/Migrations/Code/Version20200513223401.php
+++ b/Migrations/Code/Version20200513223401.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Rename elasticsearch fields to beats convention
+ */
+class Version20200513223401 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Flowpack.ElasticSearch.ContentRepositoryAdaptor-20200513223401';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $fieldMapping = [
+            '__identifier' => 'neos_node_identifier',
+            '__parentPath' => 'neos_parent_path ',
+            '__path' => 'neos_path',
+            '__typeAndSupertypes' => 'neos_type_and_supertypes',
+            '__workspace' => 'neos_workspace',
+            '_creationDateTime' => 'neos_creation_date_time',
+            '_hidden' => 'neos_hidden',
+            '_hiddenBeforeDateTime' => 'neos_hidden_before_datetime',
+            '_hiddenAfterDateTime' => 'neos_hidden_after_datetime',
+            '_hiddenInIndex' => 'neos_hidden_in_index',
+            '_lastModificationDateTime' => 'neos_last_modification_date_time',
+            '_lastPublicationDateTime' => 'neos_last_publication_date_time',
+            '__fulltextParts' => 'neos_fulltext_parts',
+            '__fulltext' => 'neos_fulltext',
+        ];
+
+        foreach ($fieldMapping as $search => $replace) {
+            $this->searchAndReplace($search, $replace, ['php', 'yaml', 'fusion']);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Neos:
     '_hiddenBeforeDateTime':
       search:
 
-        # a date should be mapped differently, and in this case we want to use a date format which
+        # A date should be mapped differently, and in this case we want to use a date format which
         # Elasticsearch understands
         elasticSearchMapping:
           type: DateTime
@@ -732,14 +732,14 @@ which is a `Document` node. However, the main content of a certain `Document` is
 in the node itself, but inside its (`Content`) child nodes.
 
 This is why we need some special functionality for indexing, which *adds the content of the inner
-nodes* to the `Document` nodes where they belong to, to a field called `__fulltext` and
-`__fulltextParts`.
+nodes* to the `Document` nodes where they belong to, to a field called `neos_fulltext` and
+`neos_fulltext_parts`.
 
 Furthermore, we want that a fulltext match e.g. inside a headline is seen as *more important* than
 a match inside the normal body text. That's why the `Document` node not only contains one field with
 all the texts, but multiple "buckets" where text is added to: One field which contains everything
-deemed as "very important" (`__fulltext.h1`), one which is "less important" (`__fulltext.h2`),
-and finally one for the plain text (`__fulltext.text`). All of these fields are configured with different `boost` values.
+deemed as "very important" (`neos_fulltext.h1`), one which is "less important" (`neos_fulltext.h2`),
+and finally one for the plain text (`neos_fulltext.text`). All of these fields are configured with different `boost` values.
 
 **For a search user interface, checkout the Flowpack.SearchPlugin package**
 

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -162,7 +162,7 @@ class ElasticSearchQueryTest extends FunctionalTestCase
             ->execute()
             ->current();
         $searchHitForNode = $queryBuilder->getFullElasticSearchHitForNode($resultNode);
-        $highlightedText = current($searchHitForNode['highlight']['__fulltext.text']);
+        $highlightedText = current($searchHitForNode['highlight']['neos_fulltext.text']);
         $expected = 'A Scout smiles and <em>whistles</em> under all circumstances.';
         static::assertEquals($expected, $highlightedText);
     }

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -138,8 +138,9 @@ class ElasticSearchQueryTest extends FunctionalTestCase
         /** @var ElasticSearchQueryResult $result */
         $result = $this->getQueryBuilder()
             ->fulltext('circum*')
+            ->log($this->getLogMessagePrefix(__METHOD__))
             ->execute();
-        $this->assertEquals(1, $result->count());
+        static::assertEquals(1, $result->count());
 
         /** @var NodeInterface $node */
         $node = $result->current();

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -65,18 +65,18 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                             'should' => [],
                             'must_not' => [
                                 [
-                                    'term' => ['_hidden' => true]
+                                    'term' => ['neos_hidden' => true]
                                 ],
                                 [
                                     'range' => [
-                                        '_hiddenBeforeDateTime' => [
+                                        'neos_hidden_before_datetime' => [
                                             'gt' => 'now'
                                         ]
                                     ]
                                 ],
                                 [
                                     'range' => [
-                                        '_hiddenAfterDateTime' => [
+                                        'neos_hidden_after_datetime' => [
                                             'lt' => 'now'
                                         ]
                                     ]
@@ -86,12 +86,12 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                     ]
                 ]
             ],
-            'fields' => ['__path']
+            'fields' => ['neos_path']
         ];
         $unsupportedFieldsInCountRequest = ['fields', 'sort', 'from', 'size', 'highlight', 'aggs', 'aggregations'];
 
         $queryStringParameters = [
-            'fields' => ['__fulltext.h1^2']
+            'fields' => ['neos_fulltext.h1^2']
         ];
 
         $this->inject($this->queryBuilder, 'elasticSearchClient', $elasticsearchClient);
@@ -121,12 +121,12 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                                         'should' => [
                                             0 => [
                                                 'term' => [
-                                                    '__parentPath' => '/foo/bar'
+                                                    'neos_parent_path' => '/foo/bar'
                                                 ]
                                             ],
                                             1 => [
                                                 'term' => [
-                                                    '__path' => '/foo/bar'
+                                                    'neos_path' => '/foo/bar'
                                                 ]
                                             ]
                                         ]
@@ -134,7 +134,7 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                                 ],
                                 1 => [
                                     'terms' => [
-                                        '__workspace' => ['live', 'user-foo']
+                                        'neos_workspace' => ['live', 'user-foo']
                                     ]
                                 ]
                             ],
@@ -142,20 +142,20 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                             'must_not' => [
                                 // Filter out all hidden elements
                                 [
-                                    'term' => ['_hidden' => true]
+                                    'term' => ['neos_hidden' => true]
                                 ],
                                 // if now < hiddenBeforeDateTime: HIDE
                                 // -> hiddenBeforeDateTime > now
                                 [
                                     'range' => [
-                                        '_hiddenBeforeDateTime' => [
+                                        'neos_hidden_before_datetime' => [
                                             'gt' => 'now'
                                         ]
                                     ]
                                 ],
                                 [
                                     'range' => [
-                                        '_hiddenAfterDateTime' => [
+                                        'neos_hidden_after_datetime' => [
                                             'lt' => 'now'
                                         ]
                                     ]
@@ -165,7 +165,7 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
                     ]
                 ]
             ],
-            'fields' => ['__path']
+            'fields' => ['neos_path']
         ];
         $actual = $this->queryBuilder->getRequest()->toArray();
         self::assertEquals($expected, $actual);
@@ -188,7 +188,7 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
         $this->queryBuilder->nodeType('Foo.Bar:Baz');
         $expected = [
             'term' => [
-                '__typeAndSupertypes' => 'Foo.Bar:Baz'
+                'neos_type_and_supertypes' => 'Foo.Bar:Baz'
             ]
         ];
         $actual = $this->queryBuilder->getRequest()->toArray();


### PR DESCRIPTION
Previously fields that are not defined via properties have been started with an underscore or sometimes with two underscores. This is generally not a problem for elasticsearch but kibana treats these fields as elasticsearch-internal and doesn’t aloow to analyze them.

Now the fields follow the rules defined in https://www.elastic.co/guide/en/beats/devguide/current/event-conventions.html

The fields are renamed as follows:

| Old | New |
|-----|-----|
|__identifier |neos_node_identifier |
|__parentPath |neos_parent_path |
|__path |neos_path|
|__typeAndSupertypes|neos_type_and_supertypes|
|__workspace |neos_workspace|
|_creationDateTime|neos_creation_date_time|
|_hidden|neos_hidden|
|_hiddenBeforeDateTime |neos_hidden_before_datetime|
|_hiddenAfterDateTime|neos_hidden_after_datetime|
|_hiddenInIndex|neos_hidden_in_index|
|_lastModificationDateTime|neos_last_modification_date_time|
|_lastPublicationDateTime|neos_last_publication_date_time|
|__fulltextParts|neos_fulltext_parts|
|__fulltext|neos_fulltext|

closes: #309 