### PR TITLE
!!! TASK: Remove fallback for fields with string mapping

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -6,29 +6,25 @@
     '__identifier':
       search:
         elasticSearchMapping:
-          type: string
-          index: not_analyzed
+          type: keyword
         indexing: '${node.identifier}'
 
     '__workspace':
       search:
         elasticSearchMapping:
-          type: string
-          index: not_analyzed
+          type: keyword
         indexing: '${node.context.workspace.name}'
 
     '__path':
       search:
         elasticSearchMapping:
-          type: string
-          index: not_analyzed
+          type: keyword
         indexing: '${node.path}'
 
     '__parentPath':
       search:
         elasticSearchMapping:
-          type: string
-          index: not_analyzed
+          type: keyword
         # we index *all* parent paths as separate tokens to allow for efficient searching without a prefix query
         indexing: '${Indexing.buildAllPathPrefixes(node.parentPath)}'
 
@@ -47,8 +43,7 @@
     '__typeAndSupertypes':
       search:
         elasticSearchMapping:
-          type: string
-          index: not_analyzed
+          type: keyword
         indexing: '${Indexing.extractNodeTypeNamesAndSupertypes(node.nodeType)}'
 
     '_lastModificationDateTime':
@@ -105,8 +100,7 @@
     'uriPathSegment':
       search:
         elasticSearchMapping:
-          type: string
-          index: not_analyzed
+          type: keyword
     title:
       search:
         fulltextExtractor: ${Indexing.extractInto('h1', value)}
@@ -123,32 +117,25 @@
           type: object
           properties:
             'h1':
-              type: string
-              index: analyzed
+              type: text
               boost: 20
             'h2':
-              type: string
-              index: analyzed
+              type: text
               boost: 12
             'h3':
-              type: string
-              index: analyzed
+              type: text
               boost: 10
             'h4':
-              type: string
-              index: analyzed
+              type: text
               boost: 5
             'h5':
-              type: string
-              index: analyzed
+              type: text
               boost: 3
             'h6':
-              type: string
-              index: analyzed
+              type: text
               boost: 2
             'text':
-              type: string
-              index: analyzed
+              type: text
               boost: 1
     '_hiddenInIndex':
       search:

--- a/Configuration/Settings.Neos.ContentRepository.Search.yaml
+++ b/Configuration/Settings.Neos.ContentRepository.Search.yaml
@@ -17,7 +17,7 @@ Neos:
 
         string:
           elasticSearchMapping:
-            type: string
+            type: keyword
 
         boolean:
           elasticSearchMapping:
@@ -43,10 +43,8 @@ Neos:
 
         'references':
           elasticSearchMapping:
-            type: string # an array of strings, to be precise
-            index: not_analyzed
+            type: keyword # an array of keywords, to be precise
 
         'reference':
           elasticSearchMapping:
-            type: string
-            index: not_analyzed
+            type: keyword

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -16,5 +16,4 @@
       type: string
       search:
         elasticSearchMapping:
-          type: string
-          index: analyzed
+          type: text

--- a/Documentation/ElasticMapping-5.x.md
+++ b/Documentation/ElasticMapping-5.x.md
@@ -1,10 +1,7 @@
-# Mapping for Elasticsearch 5.x
+# Mapping for Elasticsearch 5.x+
 
 In contrast to earlier versions, Elasticsearch has deprecated the `string` type
 in version 5. This affects the `index` setting on a field as well.
-
-This package tries to adjust the mapping on-the-fly so you may not need to
-adjust anything, but in certain cases knowing what would be correct might help.
 
 ## `string` is dead, long live strings
 

--- a/README.md
+++ b/README.md
@@ -601,8 +601,7 @@ for all your filterable properties, or else filtering won't work on them properl
       defaultValue: ''
       search:
         elasticSearchMapping:
-          type: "string"
-          index: 'not_analyzed'
+          type: keyword
 ```
 
 **Note:** When using Elasticsearch 5.x the mapping needs to be adjusted in a different way.


### PR DESCRIPTION
The field type string was removed with Elasticsearch 5.
The adapter internally mapped string to either keyword
or text depending on the not_analyzed keyword.

This mapping is removed now. Please adjust your configuration.