### PR TITLE
FEATURE: Implement asset indexing using attachment-ingest in a pipeline

### DIFF
--- a/Classes/Driver/NodeTypeMappingBuilderInterface.php
+++ b/Classes/Driver/NodeTypeMappingBuilderInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver;

--- a/Classes/Driver/PipelineDriverInterface.php
+++ b/Classes/Driver/PipelineDriverInterface.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+interface PipelineDriverInterface
+{
+    /**
+     * Creates or updates the configured ingest pipelines
+     */
+    public function updatePipelines(): void;
+
+    /**
+     * Checks if a given pipeline exists
+     *
+     * @param string $pipelineIdentifier
+     * @return bool
+     */
+    public function hasPipeLine(string $pipelineIdentifier): bool;
+
+    /**
+     * Delete a pipeline
+     *
+     * @param string $pipelineIdentifier
+     */
+    public function deletePipeLine(string $pipelineIdentifier): void;
+}

--- a/Classes/Driver/SystemDriverInterface.php
+++ b/Classes/Driver/SystemDriverInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver;

--- a/Classes/Driver/Version6/IndexerDriver.php
+++ b/Classes/Driver/Version6/IndexerDriver.php
@@ -103,8 +103,6 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
             return [];
         }
 
-        $this->logger->debug(sprintf('NodeIndexer (%s): Updated fulltext index for %s (%s)', $closestFulltextNodeDocumentIdentifier, $closestFulltextNodeContextPath, $closestFulltextNode->getIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
-
         $upsertFulltextParts = [];
         if (!empty($fulltextIndexOfNode)) {
             $upsertFulltextParts[$node->getIdentifier()] = $fulltextIndexOfNode;

--- a/Classes/Driver/Version6/PipelineDriver.php
+++ b/Classes/Driver/Version6/PipelineDriver.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\AbstractDriver;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\PipelineDriverInterface;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class PipelineDriver extends AbstractDriver implements PipelineDriverInterface
+{
+    /**
+     * @var array
+     */
+    protected $pipelineConfigurations;
+
+    /**
+     * @param array $pipelineConfigurations
+     */
+    public function __construct(array $pipelineConfigurations = [])
+    {
+        $this->pipelineConfigurations = $pipelineConfigurations;
+    }
+
+    /**
+     * @throws \Flowpack\ElasticSearch\Transfer\Exception
+     * @throws \Flowpack\ElasticSearch\Transfer\Exception\ApiException
+     * @throws \Neos\Flow\Http\Exception
+     */
+    public function updatePipelines(): void
+    {
+        foreach ($this->pipelineConfigurations as $pipelineIdentifier => $pipelineDefinition) {
+            if (($pipelineDefinition['enabled'] ?? false) === false) {
+                continue;
+            }
+
+            if (!isset($pipelineDefinition['configuration']) || !is_array($pipelineDefinition['configuration'])) {
+                continue;
+            }
+
+            $this->searchClient->request('PUT', sprintf('_ingest/pipeline/%s', $pipelineIdentifier), [], json_encode($pipelineDefinition['configuration']))->getTreatedContent();
+        }
+    }
+
+    /**
+     * @param string $pipelineIdentifier
+     * @return bool
+     * @throws \Flowpack\ElasticSearch\Transfer\Exception
+     * @throws \Flowpack\ElasticSearch\Transfer\Exception\ApiException
+     * @throws \Neos\Flow\Http\Exception
+     */
+    public function hasPipeLine(string $pipelineIdentifier): bool
+    {
+        $result = $this->searchClient->request('GET', sprintf('_ingest/pipeline/%s', $pipelineIdentifier))->getTreatedContent();
+        return !empty($result);
+    }
+
+    /**
+     * @param string $pipelineIdentifier
+     * @throws \Flowpack\ElasticSearch\Transfer\Exception
+     * @throws \Flowpack\ElasticSearch\Transfer\Exception\ApiException
+     * @throws \Neos\Flow\Http\Exception
+     */
+    public function deletePipeLine(string $pipelineIdentifier): void
+    {
+        $this->searchClient->request('DELETE', sprintf('_ingest/pipeline/%s', $pipelineIdentifier));
+    }
+}

--- a/Classes/Factory/DriverFactory.php
+++ b/Classes/Factory/DriverFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Factory;
@@ -17,6 +16,7 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Factory;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\DocumentDriverInterface;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\IndexDriverInterface;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\IndexerDriverInterface;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\PipelineDriverInterface;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\RequestDriverInterface;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\SystemDriverInterface;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\ConfigurationException;
@@ -70,5 +70,14 @@ class DriverFactory extends AbstractDriverSpecificObjectFactory
     public function createSystemDriver(): SystemDriverInterface
     {
         return $this->resolve('system');
+    }
+
+    /**
+     * @return PipelineDriverInterface
+     * @throws ConfigurationException
+     */
+    public function createPipelineManagementDriver(): PipelineDriverInterface
+    {
+        return $this->resolve('pipelineManagement');
     }
 }

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -263,7 +263,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
 
             $fulltextIndexOfNode = [];
             $nodePropertiesToBeStoredInIndex = $this->extractPropertiesAndFulltext($node, $fulltextIndexOfNode, function ($propertyName) use ($documentIdentifier, $node) {
-                $this->logger->debug(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration found, node type %s.', $documentIdentifier, $propertyName, $node->getNodeType()->getName()), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger->debug(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration was found, NodeType %s.', $documentIdentifier, $propertyName, $node->getNodeType()->getName()), LogEnvironment::fromMethodName(__METHOD__));
             });
 
             $document = new ElasticSearchDocument($mappingType,

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -29,6 +29,11 @@ Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\RequestDriverInterface:
   factoryObjectName: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Factory\DriverFactory'
   factoryMethodName: createRequestDriver
 
+Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\PipelineDriverInterface:
+  scope: singleton
+  factoryObjectName: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Factory\DriverFactory'
+  factoryMethodName: createPipelineManagementDriver
+
 Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\SystemDriverInterface:
   scope: singleton
   factoryObjectName: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Factory\DriverFactory'

--- a/Configuration/Settings.Flowpack.Elasticsearch.yaml
+++ b/Configuration/Settings.Flowpack.Elasticsearch.yaml
@@ -1,0 +1,10 @@
+Flowpack:
+  ElasticSearch:
+    indexes:
+      default:
+        neoscr:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+              default_pipeline: _none

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -48,6 +48,38 @@ Flowpack:
                   - 'aggs'
                   - 'aggregations'
                   - 'suggest'
+
+            pipelineManagement:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\PipelineDriver'
+              arguments:
+                pipelineConfigurations:
+                  neos_contentrepository:
+                    enabled: false
+                    configuration:
+                      description: 'Pipeline to ingest attachments using the ingest-attachment plugin'
+                      processors:
+                        -
+                          attachment:
+                            field: neos_asset
+                            indexed_chars: 100000
+                            ignore_missing: true
+                        -
+                          script:
+                            lang: painless
+                            source: >
+                              if (ctx.containsKey("attachment")) {
+                                 if (!ctx.containsKey("__fulltext") || !(ctx.__fulltextParts instanceof Map)) {
+                                   ctx.__fulltext = new HashMap();
+                                 }
+                                 ctx.__fulltext.text = ctx.__fulltext.text + ' ' + ctx.attachment.content
+                               }
+                        -
+                          remove:
+                            field:
+                              - attachment
+                              - neos_asset
+                            ignore_missing: true
+
             document:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\DocumentDriver'
             indexer:

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -23,3 +23,19 @@ Flowpack:
       command:
         useSubProcesses: false
 
+      driver:
+        mapping:
+          6.x:
+            pipelineManagement:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\PipelineDriver'
+              arguments:
+                pipelineConfigurations:
+                  neos_contentrepository_test:
+                    enabled: true
+                    configuration:
+                      description: 'Test Pipeline'
+                      processors:
+                        -
+                          set:
+                            field: theField
+                            value: theValue

--- a/Tests/Functional/Driver/PipelineDriverTest.php
+++ b/Tests/Functional/Driver/PipelineDriverTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Driver;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\PipelineDriverInterface;
+use Neos\Flow\Tests\FunctionalTestCase;
+
+class PipelineDriverTest extends FunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function updatePipelines(): void
+    {
+        $pipelineName = 'neos_contentrepository_test';
+
+        /** @var PipelineDriverInterface $pipelineDriver */
+        $pipelineDriver = $this->objectManager->get(PipelineDriverInterface::class);
+
+        if ($pipelineDriver->hasPipeLine($pipelineName)) {
+            $pipelineDriver->deletePipeLine($pipelineName);
+        }
+
+        $pipelineDriver->updatePipelines();
+
+        self::assertTrue($pipelineDriver->hasPipeLine($pipelineName), sprintf('Pipeline with identidfier "%s" not found', $pipelineName));
+        $pipelineDriver->deletePipeLine($pipelineName);
+        self::assertFalse($pipelineDriver->hasPipeLine($pipelineName), sprintf('Pipeline "%s" should have been deleted', $pipelineName));
+    }
+}


### PR DESCRIPTION
This is a possible solution for #323

**How it works**
After enabling the ingest pipeline and configuring it as the default pipeline for the index, you can ingest an attachment by defining: 

```
    neos_asset:
      search:
        indexing: ${Indexing.indexAsset(node.properties.asset)}
        elasticSearchMapping:
          type: text
```

`neos_asset` is a fixed identifier here. The pipeline picks the data from neos_asset and indexes it into `__fulltext.text`.

**Drawbacks**
- Only one asset per node possible
- `__fulltext.text` is only available in the node with the asset proeprty. If this is a content node, it is not set on its fulltext root.
- Feels weird to have a `neos_asset` with a special meaning

**Advantages**
- File is indexed in the pipeline, which scales better on a cluster

Closes #323