### PR TITLE
!!! FEATURE: Refactor index-time boosting to query-time boosting

### DIFF
--- a/Classes/Driver/AbstractQuery.php
+++ b/Classes/Driver/AbstractQuery.php
@@ -37,13 +37,22 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
     protected $unsupportedFieldsInCountRequest = [];
 
     /**
+     * Default parameters for the query_string filter used for fulltext search
+     *
+     * @var array
+     */
+    protected $queryStringParameters = [];
+
+    /**
      * @param array $request
      * @param array $unsupportedFieldsInCountRequest
+     * @param array $queryStringParameters
      */
-    public function __construct(array $request, array $unsupportedFieldsInCountRequest)
+    public function __construct(array $request, array $unsupportedFieldsInCountRequest, array $queryStringParameters)
     {
         $this->request = $request;
         $this->unsupportedFieldsInCountRequest = $unsupportedFieldsInCountRequest;
+        $this->queryStringParameters = $queryStringParameters;
     }
 
     /**
@@ -78,10 +87,11 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
 
     /**
      * {@inheritdoc}
+     * @throws \JsonException
      */
     public function getRequestAsJson(): string
     {
-        return json_encode($this);
+        return json_encode($this, JSON_THROW_ON_ERROR, 512);
     }
 
     /**

--- a/Classes/Driver/Version6/Query/FilteredQuery.php
+++ b/Classes/Driver/Version6/Query/FilteredQuery.php
@@ -59,10 +59,11 @@ class FilteredQuery extends AbstractQuery
     public function fulltext(string $searchWord, array $options = []): void
     {
         $this->appendAtPath('query.bool.must', [
-            'query_string' => array_merge($options, [
-                'query' => $searchWord,
-                'fields' => ['__fulltext*']
-            ])
+            'query_string' => array_merge(
+                $this->queryStringParameters,
+                $options,
+                [ 'query' => $searchWord ]
+            )
         ]);
     }
 

--- a/Configuration/NodeTypes.Override.Document.yaml
+++ b/Configuration/NodeTypes.Override.Document.yaml
@@ -24,25 +24,18 @@
           properties:
             'h1':
               type: text
-              boost: 20
             'h2':
               type: text
-              boost: 12
             'h3':
               type: text
-              boost: 10
             'h4':
               type: text
-              boost: 5
             'h5':
               type: text
-              boost: 3
             'h6':
               type: text
-              boost: 2
             'text':
               type: text
-              boost: 1
     '_hiddenInIndex':
       search:
         indexing: '${node.hiddenInIndex}'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,7 +2,7 @@ Flowpack:
   ElasticSearch:
     ContentRepositoryAdaptor:
       command:
-        useSubProcesses: false
+        useSubProcesses: true
       indexing:
         batchSize:
           elements: 500
@@ -39,6 +39,7 @@ Flowpack:
                                   lt: now
                   _source:
                     - '__path'
+
                 unsupportedFieldsInCountRequest:
                   - '_source'
                   - 'sort'
@@ -48,6 +49,21 @@ Flowpack:
                   - 'aggs'
                   - 'aggregations'
                   - 'suggest'
+
+                # Parameters for the query string query used by the fullText() operation
+                # See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-multi-field
+                # for all available parameters
+                queryStringParameters:
+                  default_operator: or
+                  fields:
+                    - __fulltext.h1^20
+                    - __fulltext.h2^12
+                    - __fulltext.h3^10
+                    - __fulltext.h4^5
+                    - __fulltext.h5^3
+                    - __fulltext.h6^2
+                    - __fulltext.text^1
+
             document:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\DocumentDriver'
             indexer:

--- a/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
+++ b/Tests/Unit/Eel/ElasticSearchQueryBuilderTest.php
@@ -90,10 +90,14 @@ class ElasticSearchQueryBuilderTest extends UnitTestCase
         ];
         $unsupportedFieldsInCountRequest = ['fields', 'sort', 'from', 'size', 'highlight', 'aggs', 'aggregations'];
 
-        $this->inject($this->queryBuilder, 'elasticSearchClient', $elasticsearchClient);
-        $this->inject($this->queryBuilder, 'request', new FilteredQuery($request, $unsupportedFieldsInCountRequest));
+        $queryStringParameters = [
+            'fields' => ['__fulltext.h1^2']
+        ];
 
-        $query = new FilteredQuery($this->queryBuilder->getRequest()->toArray(), []);
+        $this->inject($this->queryBuilder, 'elasticSearchClient', $elasticsearchClient);
+        $this->inject($this->queryBuilder, 'request', new FilteredQuery($request, $unsupportedFieldsInCountRequest, $queryStringParameters));
+
+        $query = new FilteredQuery($this->queryBuilder->getRequest()->toArray(), [], []);
         $this->inject($this->queryBuilder, 'request', $query);
         $this->queryBuilder->query($node);
     }


### PR DESCRIPTION
Index-time boosting is deprecated since elasticsearch 5.0.0.
Instead, the field mapping boost is applied at query time.

This has several advantages, especially boosting can be adjusted without reindexing  all nodes.

https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-boost.html