### PR TITLE
!!! TASK: Do not convert the nodeType name

### DIFF
--- a/Classes/Driver/AbstractNodeTypeMappingBuilder.php
+++ b/Classes/Driver/AbstractNodeTypeMappingBuilder.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver;
@@ -64,17 +63,6 @@ abstract class AbstractNodeTypeMappingBuilder implements NodeTypeMappingBuilderI
             $settings = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.ContentRepository.Search');
             $this->defaultConfigurationPerType = $settings['defaultConfigurationPerType'];
         }
-    }
-
-    /**
-     * Converts a Content Repository Node Type name into a name which can be used for an Elasticsearch Mapping
-     *
-     * @param string $nodeTypeName
-     * @return string
-     */
-    public function convertNodeTypeNameToMappingName(string $nodeTypeName): string
-    {
-        return str_replace('.', '-', $nodeTypeName);
     }
 
     /**

--- a/Classes/Driver/NodeTypeMappingBuilderInterface.php
+++ b/Classes/Driver/NodeTypeMappingBuilderInterface.php
@@ -23,15 +23,6 @@ use Neos\Error\Messages\Result;
  */
 interface NodeTypeMappingBuilderInterface
 {
-
-    /**
-     * Converts a Content Repository Node Type name into a name which can be used for an Elasticsearch Mapping
-     *
-     * @param string $nodeTypeName
-     * @return string
-     */
-    public function convertNodeTypeNameToMappingName(string $nodeTypeName): string;
-
     /**
      * Builds a Mapping Collection from the configured node types
      *

--- a/Classes/Driver/Version6/DocumentDriver.php
+++ b/Classes/Driver/Version6/DocumentDriver.php
@@ -15,7 +15,6 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6;
 
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\AbstractDriver;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\DocumentDriverInterface;
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\NodeTypeMappingBuilderInterface;
 use Flowpack\ElasticSearch\Domain\Model\Index;
 use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
@@ -31,12 +30,6 @@ use Neos\Flow\Log\Utility\LogEnvironment;
 class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
 {
     /**
-     * @Flow\Inject
-     * @var NodeTypeMappingBuilderInterface
-     */
-    protected $nodeTypeMappingBuilder;
-
-    /**
      * {@inheritdoc}
      */
     public function delete(NodeInterface $node, string $identifier): array
@@ -44,7 +37,7 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
         return [
             [
                 'delete' => [
-                    '_type' => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($node->getNodeType()->getName()),
+                    '_type' => $node->getNodeType()->getName(),
                     '_id' => $identifier
                 ]
             ]
@@ -69,7 +62,7 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
                     ],
                     'must_not' => [
                         'term' => [
-                            Mapping::NEOS_TYPE_FIELD => $this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($nodeType->getName())
+                            Mapping::NEOS_TYPE_FIELD => $nodeType->getName()
                         ]
                     ]
                 ]

--- a/Classes/Driver/Version6/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version6/Mapping/NodeTypeMappingBuilder.php
@@ -58,8 +58,7 @@ class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
                 continue;
             }
 
-            $type = $index->findType($this->convertNodeTypeNameToMappingName($nodeTypeName));
-            $mapping = new Mapping($type);
+            $mapping = new Mapping($index->findType($nodeTypeName));
             $fullConfiguration = $nodeType->getFullConfiguration();
             if (isset($fullConfiguration['search']['elasticSearchMapping'])) {
                 $fullMapping = $fullConfiguration['search']['elasticSearchMapping'];

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -259,7 +259,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
             $documentIdentifier = $this->calculateDocumentIdentifier($node, $targetWorkspaceName);
             $nodeType = $node->getNodeType();
 
-            $mappingType = $this->getIndex()->findType($this->nodeTypeMappingBuilder->convertNodeTypeNameToMappingName($nodeType->getName()));
+            $mappingType = $this->getIndex()->findType($nodeType->getName());
 
             if ($this->bulkProcessing === false) {
                 // Remove document with the same contextPathHash but different NodeType, required after NodeType change


### PR DESCRIPTION
Previously the nodeType name had to be altered to match
the constraints of an Elasticsearch type. As the type
is a simple field now, this is not needed anymore.