### PR TITLE
BUGFIX: Fix logging of queries in case of an error

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -604,7 +604,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
                 $this->result['nodes'] = $this->convertHitsToNodes($searchResult->getHits());
             }
         } catch (ApiException $exception) {
-            $this->logThisQuery && $this->logger->debug(sprintf('Query Log (%s): execution failed with message: %s', $this->logMessage, $exception->getMessage()), LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger->debug(sprintf('Query Log (%s): execution of query failed (see below), query was: %s', $this->logMessage, $this->request->getRequestAsJson()), LogEnvironment::fromMethodName(__METHOD__));
             $logMessage = $this->throwableStorage->logThrowable($exception);
             $this->logger->error($logMessage, LogEnvironment::fromMethodName(__METHOD__));
             $this->result['nodes'] = [];


### PR DESCRIPTION
When a query fails on Elasticsearch

- it will be logged now (before being sent to Elasticsearch)
- in case of an error a system log entry will be written

Fixes #340