### PR TITLE
BUGFIX: Do not specify a type when deleting nodes

### DIFF
--- a/Classes/Driver/Version6/DocumentDriver.php
+++ b/Classes/Driver/Version6/DocumentDriver.php
@@ -37,7 +37,6 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
         return [
             [
                 'delete' => [
-                    '_type' => $node->getNodeType()->getName(),
                     '_id' => $identifier
                 ]
             ]

--- a/Classes/Driver/Version6/DocumentDriver.php
+++ b/Classes/Driver/Version6/DocumentDriver.php
@@ -37,6 +37,7 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
         return [
             [
                 'delete' => [
+                    '_type' =>'_doc',
                     '_id' => $identifier
                 ]
             ]

--- a/Tests/Functional/Eel/ElasticSearchQueryTest.php
+++ b/Tests/Functional/Eel/ElasticSearchQueryTest.php
@@ -19,7 +19,7 @@ use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandCont
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryResult;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException;
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\TRaits\ContentRepositoryNodeCreationTrait;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Traits\ContentRepositoryNodeCreationTrait;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\Flow\Tests\FunctionalTestCase;

--- a/Tests/Functional/Indexer/NodeIndexerTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerTest.php
@@ -144,7 +144,7 @@ class NodeIndexerTest extends FunctionalTestCase
 
         $this->nodeIndexer->removeNode($testNode);
         $this->nodeIndexer->flush();
-        usleep(500000);
+        sleep(1);
         $this->assertFalse($this->nodeExistsInIndex($testNode), 'Node still exists after delete');
     }
 

--- a/Tests/Functional/Indexer/NodeIndexerTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerTest.php
@@ -21,7 +21,7 @@ use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\ConfigurationException;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Service\DimensionsService;
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\TRaits\ContentRepositoryNodeCreationTrait;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Traits\ContentRepositoryNodeCreationTrait;
 use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use Flowpack\ElasticSearch\Exception;
 use Flowpack\ElasticSearch\Transfer\Exception\ApiException;

--- a/Tests/Functional/Indexer/NodeIndexerTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerTest.php
@@ -13,17 +13,32 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Index
  * source code.
  */
 
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\NodeTypeMappingBuilderInterface;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\QueryInterface;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Mapping\NodeTypeMappingBuilder;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Query\FilteredQuery;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\ConfigurationException;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Service\DimensionsService;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\TRaits\ContentRepositoryNodeCreationTrait;
+use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use Flowpack\ElasticSearch\Exception;
 use Flowpack\ElasticSearch\Transfer\Exception\ApiException;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Utility\Arrays;
 
 class NodeIndexerTest extends FunctionalTestCase
 {
+    use ContentRepositoryNodeCreationTrait;
+
     const TESTING_INDEX_PREFIX = 'neoscr_testing';
+
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
 
     /**
      * @var NodeIndexer
@@ -40,12 +55,18 @@ class NodeIndexerTest extends FunctionalTestCase
      */
     protected $searchClient;
 
+    /**
+     * @var NodeTypeMappingBuilder
+     */
+    protected $nodeTypeMappingBuilder;
+
     public function setUp(): void
     {
         parent::setUp();
         $this->searchClient = $this->objectManager->get(ElasticSearchClient::class);
         $this->nodeIndexer = $this->objectManager->get(NodeIndexer::class);
         $this->dimensionService = $this->objectManager->get(DimensionsService::class);
+        $this->nodeTypeMappingBuilder = $this->objectManager->get(NodeTypeMappingBuilderInterface::class);
     }
 
     protected function tearDown(): void
@@ -61,7 +82,7 @@ class NodeIndexerTest extends FunctionalTestCase
     {
         $this->nodeIndexer->setDimensions([]);
         $index = $this->nodeIndexer->getIndex();
-        static::assertEquals(self::TESTING_INDEX_PREFIX . '-default-functionaltest', $index->getName());
+        static::assertEquals(self::TESTING_INDEX_PREFIX . '-default', $index->getName());
     }
 
     /**
@@ -78,7 +99,7 @@ class NodeIndexerTest extends FunctionalTestCase
         $index = $this->nodeIndexer->getIndex();
         $dimesionHash = $this->dimensionService->hash($dimensionValues);
 
-        static::assertEquals(self::TESTING_INDEX_PREFIX . '-' . $dimesionHash . '-functionaltest', $index->getName());
+        static::assertEquals(self::TESTING_INDEX_PREFIX . '-' . $dimesionHash, $index->getName());
     }
 
     /**
@@ -95,6 +116,36 @@ class NodeIndexerTest extends FunctionalTestCase
         $this->nodeIndexer->updateIndexAlias();
 
         $this->assertAliasesEquals(self::TESTING_INDEX_PREFIX, [$this->nodeIndexer->getIndexName()]);
+    }
+
+    /**
+     * @test
+     */
+    public function indexAndDeleteNode(): void
+    {
+        $this->setupContentRepository();
+        $this->createNodesForNodeSearchTest();
+        /** @var NodeInterface $testNode */
+        $testNode = current($this->siteNode->getChildNodes('Neos.NodeTypes:Page', 1));
+
+        $dimensionValues = ['language' => ['en_US']];
+        $this->nodeIndexer->setDimensions($dimensionValues);
+        $this->nodeIndexer->getIndex()->create();
+
+        $nodeTypeMappingCollection = $this->nodeTypeMappingBuilder->buildMappingInformation($this->nodeIndexer->getIndex());
+        foreach ($nodeTypeMappingCollection as $mapping) {
+            /** @var Mapping $mapping */
+            $mapping->apply();
+        }
+
+        $this->nodeIndexer->indexNode($testNode);
+        $this->nodeIndexer->flush();
+        $this->assertTrue($this->nodeExistsInIndex($testNode), 'Node was not successfully indexed.');
+
+        $this->nodeIndexer->removeNode($testNode);
+        $this->nodeIndexer->flush();
+        usleep(500000);
+        $this->assertFalse($this->nodeExistsInIndex($testNode), 'Node still exists after delete');
     }
 
 
@@ -114,5 +165,25 @@ class NodeIndexerTest extends FunctionalTestCase
     {
         $content = $this->searchClient->request('GET', '/_alias/' . $aliasPrefix . '*')->getTreatedContent();
         static::assertEquals($expectdAliases, array_keys($content));
+    }
+
+    /**
+     * @param NodeInterface $testNode
+     * @return bool
+     * @throws ConfigurationException
+     * @throws Exception
+     * @throws \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception
+     * @throws \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException
+     * @throws \Neos\Flow\Http\Exception
+     */
+    private function nodeExistsInIndex(NodeInterface $testNode): bool
+    {
+        $this->searchClient->setContextNode($this->siteNode);
+        /** @var FilteredQuery $query */
+        $query = $this->objectManager->get(QueryInterface::class);
+        $query->queryFilter('term', ['neos_node_identifier' => $testNode->getIdentifier()]);
+
+        $result = $this->nodeIndexer->getIndex()->request('GET', '/_search', [], $query->toArray())->getTreatedContent();
+        return count(Arrays::getValueByPath($result, 'hits.hits')) === 1;
     }
 }

--- a/Tests/Functional/Indexer/NodeIndexerTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerTest.php
@@ -80,6 +80,7 @@ class NodeIndexerTest extends FunctionalTestCase
      */
     public function getIndexWithoutDimensionConfigured(): void
     {
+        $this->nodeIndexer->setIndexNamePostfix('');
         $this->nodeIndexer->setDimensions([]);
         $index = $this->nodeIndexer->getIndex();
         static::assertEquals(self::TESTING_INDEX_PREFIX . '-default', $index->getName());

--- a/Tests/Functional/Traits/ContentRepositoryNodeCreationTrait.php
+++ b/Tests/Functional/Traits/ContentRepositoryNodeCreationTrait.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\TRaits;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\ElasticSearch\Transfer\Exception\ApiException;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Exception\NodeExistsException;
+use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
+use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Mvc\Exception\StopActionException;
+
+trait ContentRepositoryNodeCreationTrait
+{
+    /**
+     * @var WorkspaceRepository
+     */
+    protected $workspaceRepository;
+
+    /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $siteNode;
+
+    /**
+     * @var ContextFactoryInterface
+     */
+    protected $contextFactory;
+
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    private function setupContentRepository():void
+    {
+        $this->workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $liveWorkspace = new Workspace('live');
+        $this->workspaceRepository->add($liveWorkspace);
+
+        $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
+        $this->context = $this->contextFactory->create([
+            'workspaceName' => 'live',
+            'dimensions' => ['language' => ['en_US']],
+            'targetDimensions' => ['language' => 'en_US']
+        ]);
+        $rootNode = $this->context->getRootNode();
+
+        $this->siteNode = $rootNode->createNode('welcome', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $this->siteNode->setProperty('title', 'welcome');
+
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+    }
+
+    /**
+     * Creates some sample nodes to run tests against
+     *
+     * @throws NodeExistsException
+     * @throws NodeTypeNotFoundException
+     * @throws StopActionException
+     * @throws \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception
+     * @throws ApiException
+     * @throws StopCommandException
+     */
+    protected function createNodesForNodeSearchTest(): void
+    {
+        $newDocumentNode1 = $this->siteNode->createNode('test-node-1', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $newDocumentNode1->setProperty('title', 'chicken');
+        $newDocumentNode1->setProperty('title_analyzed', 'chicken');
+
+        $newContentNode1 = $newDocumentNode1->getNode('main')->createNode('document-1-text-1', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Text'));
+        $newContentNode1->setProperty('text', 'A Scout smiles and whistles under all circumstances.');
+
+        $newDocumentNode2 = $this->siteNode->createNode('test-node-2', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $newDocumentNode2->setProperty('title', 'chicken');
+        $newDocumentNode2->setProperty('title_analyzed', 'chicken');
+
+        // Nodes for cacheLifetime test
+        $newContentNode2 = $newDocumentNode2->getNode('main')->createNode('document-2-text-1', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Text'));
+        $newContentNode2->setProperty('text', 'Hidden after 2025-01-01');
+        $newContentNode2->setHiddenAfterDateTime(new \DateTime('@1735686000'));
+        $newContentNode3 = $newDocumentNode2->getNode('main')->createNode('document-2-text-2', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Text'));
+        $newContentNode3->setProperty('text', 'Hidden before 2018-07-18');
+        $newContentNode3->setHiddenBeforeDateTime(new \DateTime('@1531864800'));
+
+        $newDocumentNode3 = $this->siteNode->createNode('test-node-3', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $newDocumentNode3->setProperty('title', 'egg');
+        $newDocumentNode3->setProperty('title_analyzed', 'egg');
+
+        $dimensionContext = $this->contextFactory->create([
+            'workspaceName' => 'live',
+            'dimensions' => ['language' => ['de']]
+        ]);
+        $translatedNode3 = $dimensionContext->adoptNode($newDocumentNode3, true);
+        $translatedNode3->setProperty('title', 'De');
+
+        $this->persistenceManager->persistAll();
+    }
+}

--- a/Tests/Functional/Traits/ContentRepositoryNodeCreationTrait.php
+++ b/Tests/Functional/Traits/ContentRepositoryNodeCreationTrait.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\TRaits;
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Traits;
 
 /*
  * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.


### PR DESCRIPTION
Removal of nodes from the index was simply broken and failed (apart from the logs) silently.
Added a test for node indexing and deletion and fixed the issue.