### PR TITLE
BUGFIX: Trying to use response from exception as string

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -320,7 +320,7 @@ class NodeIndexCommandController extends CommandController
                 $this->logger->info('Nothing to remove.', LogEnvironment::fromMethodName(__METHOD__));
             }
         } catch (ApiException $exception) {
-            $response = json_decode($exception->getResponse());
+            $response = json_decode($exception->getResponse()->getBody()->getContents());
             if ($response->error instanceof \stdClass) {
                 $this->logger->info(sprintf('Nothing removed. ElasticSearch responded with status %s, saying "%s: %s"', $response->status, $response->error->type, $response->error->reason), LogEnvironment::fromMethodName(__METHOD__));
             } else {

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -219,7 +219,8 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
                 $this->logger->debug(sprintf('NodeIndexer (%s) - Property "%s" not indexed because no configuration found, node type %s.', $documentIdentifier, $propertyName, $node->getNodeType()->getName()), LogEnvironment::fromMethodName(__METHOD__));
             });
 
-            $document = new ElasticSearchDocument($mappingType,
+            $document = new ElasticSearchDocument(
+                $mappingType,
                 $nodePropertiesToBeStoredInIndex,
                 $documentIdentifier
             );


### PR DESCRIPTION
The return value of `ApiException->getResponse()` is no longer a
string, so decoding it as JSON fails.