### PR TITLE
BUGFIX: Make return type nullable

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -558,7 +558,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      * @param NodeInterface $node
      * @return array the Elasticsearch hit for the node as array, or NULL if it does not exist.
      */
-    public function getFullElasticSearchHitForNode(NodeInterface $node): array
+    public function getFullElasticSearchHitForNode(NodeInterface $node): ?array
     {
         return $this->elasticSearchHitsIndexedByNodeFromLastRequest[$node->getIdentifier()] ?? null;
     }

--- a/Classes/Eel/ElasticSearchQueryResult.php
+++ b/Classes/Eel/ElasticSearchQueryResult.php
@@ -252,7 +252,7 @@ class ElasticSearchQueryResult implements QueryResultInterface, ProtectedContext
      * @return array the Elasticsearch hit, or NULL if it does not exist.
      * @api
      */
-    public function searchHitForNode(NodeInterface $node): array
+    public function searchHitForNode(NodeInterface $node): ?array
     {
         return $this->elasticSearchQuery->getQueryBuilder()->getFullElasticSearchHitForNode($node);
     }


### PR DESCRIPTION
As the comment and code says, these might return `null`:

- `searchHitForNode()`
- `getFullElasticSearchHitForNode()`



