### PR TITLE
Decouple tests from nodetype-package, add test for multi-dimension-scenario

### DIFF
--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -17,3 +17,20 @@
       search:
         elasticSearchMapping:
           type: text
+
+'Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document':
+  superTypes:
+    'Neos.Neos:Document': true
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'
+
+'Flowpack.ElasticSearch.ContentRepositoryAdaptor:Content':
+  superTypes:
+    'Neos.Neos:Content': true
+  properties:
+    text:
+      type: string
+      defaultValue: ''
+      search:
+        fulltextExtractor: '${Indexing.extractHtmlTags(value)}'

--- a/Tests/Functional/Indexer/NodeIndexerDimensionsTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerDimensionsTest.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Indexer;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use DateTime;
+use DateTimeImmutable;
+use Exception;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\QueryInterface;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Query\FilteredQuery;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Traits\ContentRepositoryMultiDimensionNodeCreationTrait;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Utility\Arrays;
+
+class NodeIndexerDimensionsTest extends FunctionalTestCase
+{
+    use ContentRepositoryMultiDimensionNodeCreationTrait;
+
+    const TESTING_INDEX_PREFIX = 'neoscr_testing';
+
+    /**
+     * @var ElasticSearchClient
+     */
+    protected $searchClient;
+
+    /**
+     * @var NodeIndexCommandController
+     */
+    protected $nodeIndexCommandController;
+
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var NodeIndexer
+     */
+    protected $nodeIndexer;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $siteNodeDefault;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $siteNodeDe;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $siteNodeDk;
+
+    /**
+     * @var boolean
+     */
+    protected static $indexInitialized = false;
+
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nodeIndexer = $this->objectManager->get(NodeIndexer::class);
+        $this->searchClient = $this->objectManager->get(ElasticSearchClient::class);
+
+        if (self::$indexInitialized !== true) {
+            // clean up any existing indices
+            $this->searchClient->request('DELETE', '/' . self::TESTING_INDEX_PREFIX . '*');
+        }
+
+
+        $this->nodeIndexCommandController = $this->objectManager->get(NodeIndexCommandController::class);
+        $this->setupContentRepository();
+        $this->createNodesForNodeSearchTest();
+        $this->indexNodes();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+    }
+
+    /**
+     * @test
+     */
+    public function countDimensionNodesTest(): void
+    {
+        // expecting: root, document1, untranslated = 3
+        static::assertEquals(3, $this->getNodeCountInDimension('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document', $this->siteNodeDefault->getDimensions()));
+
+        // expecting: root, document1, document2, document3, document4, untranslated (fallback from en_us) = 6
+        static::assertEquals(6, $this->getNodeCountInDimension('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document', $this->siteNodeDe->getDimensions()));
+
+        // expecting: root, document1, document2, document4 (fallback from de), untranslated (fallback from en_us) = 5
+        static::assertEquals(5, $this->getNodeCountInDimension('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document', $this->siteNodeDk->getDimensions()));
+
+    }
+
+    protected function getNodeCountInDimension(string $nodeTypeName, array $dimensions): int
+    {
+        /** @var FilteredQuery $query */
+        $query = $this->objectManager->get(QueryInterface::class);
+        $query->queryFilter('term', ['neos_type' => $nodeTypeName]);
+
+        $this->nodeIndexer->setDimensions($dimensions);
+        $result = $this->nodeIndexer->getIndex()->request('GET', '/_search', [], $query->toArray())->getTreatedContent();
+        return Arrays::getValueByPath($result, 'hits.total.value');
+    }
+
+    protected function indexNodes(): void
+    {
+        if (self::$indexInitialized === true) {
+            return;
+        }
+
+        $this->nodeIndexCommandController->buildCommand(null, false, 'live');
+        self::$indexInitialized = true;
+    }
+
+    /**
+     * @param string $method
+     * @return string
+     */
+    protected function getLogMessagePrefix(string $method): string
+    {
+        return substr(strrchr($method, '\\'), 1);
+    }
+
+    /**
+     * @return ElasticSearchQueryBuilder
+     */
+    protected function getQueryBuilder(): ElasticSearchQueryBuilder
+    {
+        try {
+            $elasticSearchQueryBuilder = $this->objectManager->get(ElasticSearchQueryBuilder::class);
+            $this->inject($elasticSearchQueryBuilder, 'now', new DateTimeImmutable('@1735685400')); // Dec. 31, 2024 23:50:00
+
+            return $elasticSearchQueryBuilder;
+        } catch (Exception $exception) {
+            static::fail('Setting up the QueryBuilder failed: ' . $exception->getMessage());
+        }
+    }
+}

--- a/Tests/Functional/Indexer/NodeIndexerDimensionsTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerDimensionsTest.php
@@ -112,7 +112,6 @@ class NodeIndexerDimensionsTest extends FunctionalTestCase
 
         // expecting: root, document1, document2, document4 (fallback from de), untranslated (fallback from en_us) = 5
         static::assertEquals(5, $this->getNodeCountInDimension('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document', $this->siteNodeDk->getDimensions()));
-
     }
 
     protected function getNodeCountInDimension(string $nodeTypeName, array $dimensions): int
@@ -159,4 +158,5 @@ class NodeIndexerDimensionsTest extends FunctionalTestCase
             static::fail('Setting up the QueryBuilder failed: ' . $exception->getMessage());
         }
     }
+
 }

--- a/Tests/Functional/Indexer/NodeIndexerDimensionsTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerDimensionsTest.php
@@ -158,5 +158,4 @@ class NodeIndexerDimensionsTest extends FunctionalTestCase
             static::fail('Setting up the QueryBuilder failed: ' . $exception->getMessage());
         }
     }
-
 }

--- a/Tests/Functional/Indexer/NodeIndexerTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerTest.php
@@ -60,6 +60,11 @@ class NodeIndexerTest extends FunctionalTestCase
      */
     protected $nodeTypeMappingBuilder;
 
+    /**
+     * @var boolean
+     */
+    protected static $indexInitialized = false;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -67,6 +72,7 @@ class NodeIndexerTest extends FunctionalTestCase
         $this->nodeIndexer = $this->objectManager->get(NodeIndexer::class);
         $this->dimensionService = $this->objectManager->get(DimensionsService::class);
         $this->nodeTypeMappingBuilder = $this->objectManager->get(NodeTypeMappingBuilderInterface::class);
+        $this->searchClient->request('DELETE', '/' . self::TESTING_INDEX_PREFIX . '*');
     }
 
     protected function tearDown(): void
@@ -127,7 +133,7 @@ class NodeIndexerTest extends FunctionalTestCase
         $this->setupContentRepository();
         $this->createNodesForNodeSearchTest();
         /** @var NodeInterface $testNode */
-        $testNode = current($this->siteNode->getChildNodes('Neos.NodeTypes:Page', 1));
+        $testNode = current($this->siteNode->getChildNodes('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document', 1));
 
         $dimensionValues = ['language' => ['en_US']];
         $this->nodeIndexer->setDimensions($dimensionValues);

--- a/Tests/Functional/Traits/ContentRepositoryMultiDimensionNodeCreationTrait.php
+++ b/Tests/Functional/Traits/ContentRepositoryMultiDimensionNodeCreationTrait.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional\Traits;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\ElasticSearch\Transfer\Exception\ApiException;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\NodeDataRepository;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\Context;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Exception\NodeExistsException;
+use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
+use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\Mvc\Exception\StopActionException;
+
+trait ContentRepositoryMultiDimensionNodeCreationTrait
+{
+    /**
+     * @var WorkspaceRepository
+     */
+    protected $workspaceRepository;
+
+    /**
+     * @var NodeInterface
+     */
+    protected $siteNode;
+
+    /**
+     * @var ContextFactoryInterface
+     */
+    protected $contextFactory;
+
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var NodeDataRepository
+     */
+    protected $nodeDataRepository;
+
+    private function setupContentRepository():void
+    {
+        $this->workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $liveWorkspace = new Workspace('live');
+        $this->workspaceRepository->add($liveWorkspace);
+
+        $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
+        $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
+    }
+
+    /**
+     * Creates some sample nodes to run tests against
+     *
+     * @throws NodeExistsException
+     * @throws NodeTypeNotFoundException
+     * @throws StopActionException
+     * @throws \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception
+     * @throws ApiException
+     * @throws StopCommandException
+     */
+    protected function createNodesForNodeSearchTest(): void
+    {
+        $defaultLanguageDimensionContext = $this->contextFactory->create([
+            'workspaceName' => 'live',
+            'dimensions' => ['language' => ['en_US']],
+            'targetDimensions' => ['language' => 'en_US']
+        ]);
+        $deLanguageDimensionContext = $this->contextFactory->create([
+            'workspaceName' => 'live',
+            'dimensions' => ['language' => ['de']],
+            'targetDimensions' => ['language' => 'de']
+        ]);
+        $dkLanguageDimensionContext = $this->contextFactory->create([
+            'workspaceName' => 'live',
+            'dimensions' => ['language' => ['dk']],
+            'targetDimensions' => ['language' => 'dk']
+        ]);
+
+        $rootNode = $defaultLanguageDimensionContext->getRootNode();
+        $this->siteNodeDefault = $rootNode->createNode('root', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $this->siteNodeDefault->setProperty('title', 'root-default');
+        $this->siteNodeDe = $deLanguageDimensionContext->adoptNode($this->siteNodeDefault, true);
+        $this->siteNodeDe->setProperty('title', 'root-de');
+        $this->siteNodeDk = $dkLanguageDimensionContext->adoptNode($this->siteNodeDefault, true);
+        $this->siteNodeDk->setProperty('title', 'root-dk');
+
+        // add a document node that is translated in two languages
+        $newDocumentNode1 = $this->siteNodeDefault->createNode('document1-default', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $newDocumentNode1->setProperty('title', 'document1-default');
+
+        $translatedDocumentNode1De = $deLanguageDimensionContext->adoptNode($newDocumentNode1, true);
+        $translatedDocumentNode1De->setProperty('title', 'document1-de');
+        $translatedDocumentNode1Dk = $dkLanguageDimensionContext->adoptNode($newDocumentNode1, true);
+        $translatedDocumentNode1Dk->setProperty('title', 'document1-dk');
+
+        // add a document node that is not translated
+        $newDocumentNode_untranslated = $this->siteNodeDefault->createNode('document-untranslated', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $newDocumentNode_untranslated->setProperty('title', 'document-untranslated');
+
+        // add additional, but separate nodes here
+        $standaloneDocumentNode2De = $this->siteNodeDe->createNode('document2-de', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $standaloneDocumentNode2De->setProperty('title', 'document2-de');
+
+        $standaloneDocumentNode2Dk = $this->siteNodeDk->createNode('document2-dk', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $standaloneDocumentNode2Dk->setProperty('title', 'document2-dk');
+
+        // add an additional german node
+        $documentNodeDe3 = $standaloneDocumentNode2De->createNode('document3-de', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $documentNodeDe3->setProperty('title', 'document3-de');
+
+        // add another german node, but translate it to danish
+        $documentNodeDe4 = $standaloneDocumentNode2De->createNode('document4-de', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
+        $documentNodeDe4->setProperty('title', 'document4-de');
+
+        $translatedDocumentNode4Dk = $dkLanguageDimensionContext->adoptNode($documentNodeDe4, true);
+        $translatedDocumentNode4Dk->setProperty('title', 'document4-dk');
+
+        $this->persistenceManager->persistAll();
+    }
+}

--- a/Tests/Functional/Traits/ContentRepositoryNodeCreationTrait.php
+++ b/Tests/Functional/Traits/ContentRepositoryNodeCreationTrait.php
@@ -73,7 +73,7 @@ trait ContentRepositoryNodeCreationTrait
         ]);
         $rootNode = $this->context->getRootNode();
 
-        $this->siteNode = $rootNode->createNode('welcome', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $this->siteNode = $rootNode->createNode('welcome', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
         $this->siteNode->setProperty('title', 'welcome');
 
         $this->nodeDataRepository = $this->objectManager->get(NodeDataRepository::class);
@@ -91,26 +91,26 @@ trait ContentRepositoryNodeCreationTrait
      */
     protected function createNodesForNodeSearchTest(): void
     {
-        $newDocumentNode1 = $this->siteNode->createNode('test-node-1', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $newDocumentNode1 = $this->siteNode->createNode('test-node-1', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
         $newDocumentNode1->setProperty('title', 'chicken');
         $newDocumentNode1->setProperty('title_analyzed', 'chicken');
 
-        $newContentNode1 = $newDocumentNode1->getNode('main')->createNode('document-1-text-1', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Text'));
+        $newContentNode1 = $newDocumentNode1->getNode('main')->createNode('document-1-text-1', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Content'));
         $newContentNode1->setProperty('text', 'A Scout smiles and whistles under all circumstances.');
 
-        $newDocumentNode2 = $this->siteNode->createNode('test-node-2', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $newDocumentNode2 = $this->siteNode->createNode('test-node-2', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
         $newDocumentNode2->setProperty('title', 'chicken');
         $newDocumentNode2->setProperty('title_analyzed', 'chicken');
 
         // Nodes for cacheLifetime test
-        $newContentNode2 = $newDocumentNode2->getNode('main')->createNode('document-2-text-1', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Text'));
+        $newContentNode2 = $newDocumentNode2->getNode('main')->createNode('document-2-text-1', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Content'));
         $newContentNode2->setProperty('text', 'Hidden after 2025-01-01');
         $newContentNode2->setHiddenAfterDateTime(new \DateTime('@1735686000'));
-        $newContentNode3 = $newDocumentNode2->getNode('main')->createNode('document-2-text-2', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Text'));
+        $newContentNode3 = $newDocumentNode2->getNode('main')->createNode('document-2-text-2', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Content'));
         $newContentNode3->setProperty('text', 'Hidden before 2018-07-18');
         $newContentNode3->setHiddenBeforeDateTime(new \DateTime('@1531864800'));
 
-        $newDocumentNode3 = $this->siteNode->createNode('test-node-3', $this->nodeTypeManager->getNodeType('Neos.NodeTypes:Page'));
+        $newDocumentNode3 = $this->siteNode->createNode('test-node-3', $this->nodeTypeManager->getNodeType('Flowpack.ElasticSearch.ContentRepositoryAdaptor:Document'));
         $newDocumentNode3->setProperty('title', 'egg');
         $newDocumentNode3->setProperty('title_analyzed', 'egg');
 


### PR DESCRIPTION
- added nodetype definitions for a document and a content nodetype
- use those nodetypes in existing tests (instead on reliying on the existence of the nodetype-package)
- add indexer test for multi-dimension scenario (fails currently as excpected)

