### PR TITLE
TASK: Adjust filter allowing to unset elasticSearchMapping parameters

### DIFF
--- a/Classes/Driver/Version6/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version6/Mapping/NodeTypeMappingBuilder.php
@@ -73,7 +73,9 @@ class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
 
                 if (isset($propertyConfiguration['search']['elasticSearchMapping'])) {
                     if (is_array($propertyConfiguration['search']['elasticSearchMapping'])) {
-                        $propertyMapping = array_filter($propertyConfiguration['search']['elasticSearchMapping']);
+                        $propertyMapping = array_filter($propertyConfiguration['search']['elasticSearchMapping'], static function ($value) {
+                            return $value !== null;
+                        });
                         $mapping->setPropertyByPath($propertyName, $propertyMapping);
                     }
                 } elseif (isset($propertyConfiguration['type'], $this->defaultConfigurationPerType[$propertyConfiguration['type']]['elasticSearchMapping'])) {


### PR DESCRIPTION
A follow-up to #372: Only filter null values, but keep false and any
other value considered `empty()` by PHP.

Related #375