### PR TITLE
Use Node Identifier, Fix ES Duplicates 

### DIFF
--- a/Classes/Driver/Version6/IndexerDriver.php
+++ b/Classes/Driver/Version6/IndexerDriver.php
@@ -13,7 +13,7 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6;
  * source code.
  */
 
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Domain\Model\TargetContextPath;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\AbstractIndexerDriver;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\IndexerDriverInterface;
 use Flowpack\ElasticSearch\Domain\Model\Document as ElasticSearchDocument;
@@ -90,11 +90,7 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
             return [];
         }
 
-        $closestFulltextNodeContextPath = $closestFulltextNode->getContextPath();
-        if ($targetWorkspaceName !== null) {
-            $closestFulltextNodeContextPath = (string)(new TargetContextPath($node, $targetWorkspaceName, $closestFulltextNodeContextPath));
-        }
-        $closestFulltextNodeDocumentIdentifier = sha1($closestFulltextNodeContextPath);
+        $closestFulltextNodeDocumentIdentifier = NodeIndexer::calculateDocumentIdentifier($closestFulltextNode);
 
         if ($closestFulltextNode->isRemoved()) {
             // fulltext root is removed, abort silently...

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -243,7 +243,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
                 }
             }
 
-            $documentIdentifier = $this->calculateDocumentIdentifier($node, $targetWorkspaceName);
+            $documentIdentifier = NodeIndexer::calculateDocumentIdentifier($node, $targetWorkspaceName);
             $nodeType = $node->getNodeType();
 
             $mappingType = $this->getIndex()->findType($nodeType->getName());
@@ -346,11 +346,11 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
      * Returns a stable identifier for the Elasticsearch document representing the node
      *
      * @param NodeInterface $node
-     * @param string $targetWorkspaceName
+     * @param null $targetWorkspaceName
      * @return string
      * @throws IllegalObjectTypeException
      */
-    protected function calculateDocumentIdentifier(NodeInterface $node, $targetWorkspaceName = null): string
+    public static function calculateDocumentIdentifier(NodeInterface $node, $targetWorkspaceName = null): string
     {
         $workspaceName = $targetWorkspaceName ?: $node->getWorkspace()->getName();
         $nodeIdentifier = $node->getIdentifier();
@@ -384,7 +384,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
             }
         }
 
-        $documentIdentifier = $this->calculateDocumentIdentifier($node, $targetWorkspaceName);
+        $documentIdentifier = NodeIndexer::calculateDocumentIdentifier($node, $targetWorkspaceName);
 
         $this->toBulkRequest($node, $this->documentDriver->delete($node, $documentIdentifier));
         $this->toBulkRequest($node, $this->indexerDriver->fulltext($node, [], $targetWorkspaceName));

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -346,7 +346,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
      * Returns a stable identifier for the Elasticsearch document representing the node
      *
      * @param NodeInterface $node
-     * @param null $targetWorkspaceName
+     * @param string|null $targetWorkspaceName
      * @return string
      * @throws IllegalObjectTypeException
      */

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -274,6 +274,13 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
         $handleNode = function (NodeInterface $node, Context $context) use ($targetWorkspaceName, $indexer) {
             $nodeFromContext = $context->getNodeByIdentifier($node->getIdentifier());
             if ($nodeFromContext instanceof NodeInterface) {
+                if ($node->getPath() !== $nodeFromContext->getPath()) {
+                    // If the node from context does have a different path, purge the context cache and re-fetch
+
+                    // TODO: find a better way to handle this
+                    $context->getFirstLevelNodeCache()->flush();
+                    $nodeFromContext = $context->getNodeByIdentifier($node->getIdentifier());
+                }
                 $this->searchClient->withDimensions(static function () use ($indexer, $nodeFromContext, $targetWorkspaceName) {
                     $indexer($nodeFromContext, $targetWorkspaceName);
                 }, $nodeFromContext->getContext()->getTargetDimensions());

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -352,13 +352,10 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
      */
     protected function calculateDocumentIdentifier(NodeInterface $node, $targetWorkspaceName = null): string
     {
-        $contextPath = $node->getContextPath();
+        $workspaceName = $targetWorkspaceName ?: $node->getWorkspace()->getName();
+        $nodeIdentifier = $node->getIdentifier();
 
-        if ($targetWorkspaceName !== null) {
-            $contextPath = (string)(new TargetContextPath($node, $targetWorkspaceName, $contextPath));
-        }
-
-        return sha1($contextPath);
+        return sha1($nodeIdentifier . $workspaceName);
     }
 
     /**

--- a/Tests/Functional/Indexer/NodeIndexerTest.php
+++ b/Tests/Functional/Indexer/NodeIndexerTest.php
@@ -148,7 +148,8 @@ class NodeIndexerTest extends BaseElasticsearchContentRepositoryAdapterTest
     /**
      * Fetch the node path (stored in elasticsearch) of the given node
      */
-    private function getNeosPathOfNodeInIndex(NodeInterface $node): ?string {
+    private function getNeosPathOfNodeInIndex(NodeInterface $node): ?string
+    {
         $this->searchClient->setContextNode($this->siteNode);
         /** @var FilteredQuery $query */
         $query = $this->objectManager->get(QueryInterface::class);


### PR DESCRIPTION
## Abstract

This changes the way the Elasticsearch document identifier is being calculated by using the node identifier instead of the node path.

## Resolves

* https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor/issues/353

## Rationale

Using the node path to deduce the identifier in Elasticsearch has some flaws and bad side effects when moving nodes around; in that case, especially when using an async node indexing (e.g. by using the [ES Queue Indexer](https://www.neos.io/de/download/pakete/flowpack/flowpack-elasticsearch-contentrepositoryqueueindexer.html)), the indexing process will produce duplicates, basically it will leave the old node around and index a new node (with the correct path) and this will cause race conditions when doing ES queries and also issues when doing e.g. pagination etc.

## Breaking

This change will **require** a "flow:nodeindex", so maybe a minor (or major?) release will the way to go. 

## Implementation Details

In addition to the logic change this also makes the existing implementation more DRY by removing the duplicated code in the `IndexerDriver` - see 1baf54e.

## Testing

This also adds an implementation for the existing `NodeIndexerTest::nodeMoveIsHandledCorrectly()` test method.

To run the functional tests in e.g. docker, do:

```shell
FLOW_CONTEXT="Testing/ElasticVersion6" bin/phpunit --colors --stop-on-failure \
  -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml \
  Packages/Application/Flowpack.ElasticSearch.ContentRepositoryAdaptor/Tests/Functional
```

## Discussion

I will like to port this change to older versions as well so this will also work in older Neos 4.3 projects..