### PR TITLE
BUGFIX: Replace hard coded ContextFactory references with the interface

### DIFF
--- a/Classes/Command/SearchCommandController.php
+++ b/Classes/Command/SearchCommandController.php
@@ -21,7 +21,7 @@ use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception\QueryBuildingException;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\Context;
-use Neos\ContentRepository\Domain\Service\ContextFactory;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
@@ -34,7 +34,7 @@ use Neos\Utility\Arrays;
 class SearchCommandController extends CommandController
 {
     /**
-     * @var ContextFactory
+     * @var ContextFactoryInterface
      * @Flow\Inject
      */
     protected $contextFactory;

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -33,7 +33,7 @@ use Flowpack\ElasticSearch\Transfer\Exception\ApiException;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\ContentDimensionCombinator;
 use Neos\ContentRepository\Domain\Service\Context;
-use Neos\ContentRepository\Domain\Service\ContextFactory;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\ContentRepository\Search\Indexer\AbstractNodeIndexer;
 use Neos\ContentRepository\Search\Indexer\BulkNodeIndexerInterface;
 use Neos\Flow\Annotations as Flow;
@@ -90,7 +90,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
 
     /**
      * @Flow\Inject
-     * @var ContextFactory
+     * @var ContextFactoryInterface
      */
     protected $contextFactory;
 

--- a/Classes/Indexer/WorkspaceIndexer.php
+++ b/Classes/Indexer/WorkspaceIndexer.php
@@ -16,7 +16,7 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\ContentDimensionCombinator;
-use Neos\ContentRepository\Domain\Service\ContextFactory;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\ContentRepository\Search\Indexer\NodeIndexingManager;
 use Neos\Flow\Annotations as Flow;
 
@@ -28,7 +28,7 @@ use Neos\Flow\Annotations as Flow;
 final class WorkspaceIndexer
 {
     /**
-     * @var ContextFactory
+     * @var ContextFactoryInterface
      * @Flow\Inject
      */
     protected $contextFactory;

--- a/Classes/Service/IndexWorkspaceTrait.php
+++ b/Classes/Service/IndexWorkspaceTrait.php
@@ -31,7 +31,7 @@ trait IndexWorkspaceTrait
 
     /**
      * @Flow\Inject
-     * @var \Neos\ContentRepository\Domain\Service\ContextFactory
+     * @var \Neos\ContentRepository\Domain\Service\ContextFactoryInterface
      */
     protected $contextFactory;
 

--- a/Tests/Functional/BaseElasticsearchContentRepositoryAdapterTest.php
+++ b/Tests/Functional/BaseElasticsearchContentRepositoryAdapterTest.php
@@ -16,7 +16,7 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Tests\Functional;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Command\NodeIndexCommandController;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilder;
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
-use Neos\ContentRepository\Domain\Service\ContextFactory;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 abstract class BaseElasticsearchContentRepositoryAdapterTest extends FunctionalTestCase
@@ -52,7 +52,7 @@ abstract class BaseElasticsearchContentRepositoryAdapterTest extends FunctionalT
     {
         parent::tearDown();
 
-        if (isset($this->contextFactory) && $this->contextFactory instanceof ContextFactory) {
+        if (isset($this->contextFactory) && $this->contextFactory instanceof ContextFactoryInterface) {
             $this->inject($this->contextFactory, 'contextInstances', []);
         }
 


### PR DESCRIPTION
This replaces the use of the `ContextFactory` of the ContentRepository package in several places with the `ContextFactoryInterface` instead.

That fixes failures like
```
Call to undefined method Neos\ContentRepository\Domain\Service\Context::getCurrentSiteNode() [...]
```
when expecting a *Neos*  context during indexing.

Fixes: #380