### PR TITLE
TASK: Configure ignore_above for keyword fields

### DIFF
--- a/Configuration/Settings.Neos.ContentRepository.Search.yaml
+++ b/Configuration/Settings.Neos.ContentRepository.Search.yaml
@@ -18,6 +18,7 @@ Neos:
         string:
           elasticSearchMapping:
             type: keyword
+            ignore_above: 8191
 
         boolean:
           elasticSearchMapping:
@@ -26,6 +27,7 @@ Neos:
         array:
           elasticSearchMapping:
             type: keyword
+            ignore_above: 8191
 
         integer:
           elasticSearchMapping:


### PR DESCRIPTION
This sets ignore_above of keyword fields to 8191 according to
https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html#ignore-above
which avoids "Document contains at least one immense term in field" errors
when indexing fields containing lots of text.