### PR TITLE
PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://flowpack.org/",
     "license": ["LGPL-3.0-only"],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
 
         "flowpack/elasticsearch": "^5.0 || dev-master",


### PR DESCRIPTION
Changing `"^7.3` to `"^7.3 || ^8.0"` seems to be (almost) enough for me. 

Only bug I got in my checks was related to `\Neos\ContentRepository\Search\Eel\IndexingHelper::extractHtmlTags()`

There is a str_replace in it, which (oh wonder) only accepts strings as input. Since PHP 8, it doesn’t accept NULL-Values anymore. But if a property isn’t set, this leads to an error while indexing.  
I solved it by adding a condition in the NodeTypes: `fulltextExtractor: '${Indexing.extractHtmlTags(value ? value : "")}'`
But  I’m not sure, if that is something, we should handle for the user. It would be easy to also accept a NULL-value and set the method-property to an empty string, if NULL was given. So the user wouldn’t have to take care about (as it was with PHP 7)

It is quite possible that there are other problems. These were just the experiences I had during the upgrade.