### PR TITLE
BUGFIX: Keep fulltext index of hidden nodes as those may be searched in backend use cases

### DIFF
--- a/Classes/Driver/Version6/IndexerDriver.php
+++ b/Classes/Driver/Version6/IndexerDriver.php
@@ -126,7 +126,7 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
                             ctx._source.neos_fulltext_parts = new HashMap();
                         }
 
-                        if (params.nodeIsRemoved || params.nodeIsHidden || params.fulltext.size() == 0) {
+                        if (params.nodeIsRemoved || params.fulltext.size() == 0) {
                             if (ctx._source.neos_fulltext_parts.containsKey(params.identifier)) {
                                 ctx._source.neos_fulltext_parts.remove(params.identifier);
                             }
@@ -148,7 +148,6 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
                     'params' => [
                         'identifier' => $node->getIdentifier(),
                         'nodeIsRemoved' => $node->isRemoved(),
-                        'nodeIsHidden' => $node->isHidden(),
                         'fulltext' => $fulltextIndexOfNode
                     ],
                 ],


### PR DESCRIPTION
The fulltext fields for hidden nodes previously were calculated but then not stored. This makes sense for removed nodes but hidden nodes exist and may be found by users that have the correct permissions.