### PR TITLE
FEATURE: Extended highlight configuration

### DIFF
--- a/Classes/Driver/AbstractQuery.php
+++ b/Classes/Driver/AbstractQuery.php
@@ -180,22 +180,19 @@ abstract class AbstractQuery implements QueryInterface, \JsonSerializable, \Arra
     /**
      * {@inheritdoc}
      */
-    public function highlight($fragmentSize, int $fragmentCount = null): void
+    public function highlight($fragmentSize, int $fragmentCount = null, int $noMatchSize = 150, string $field = 'neos_fulltext.*'): void
     {
         if ($fragmentSize === false) {
             // Highlighting is disabled.
             unset($this->request['highlight']);
-        } else {
-            $this->request['highlight'] = [
-                'fields' => [
-                    'neos_fulltext*' => [
-                        'fragment_size' => $fragmentSize,
-                        'no_match_size' => $fragmentSize,
-                        'number_of_fragments' => $fragmentCount
-                    ]
-                ]
-            ];
+            return;
         }
+
+        $this->request['highlight']['fields'][$field] = [
+            'fragment_size' => $fragmentSize,
+            'no_match_size' => $noMatchSize,
+            'number_of_fragments' => $fragmentCount
+        ];
     }
 
     /**

--- a/Classes/Driver/QueryInterface.php
+++ b/Classes/Driver/QueryInterface.php
@@ -86,11 +86,13 @@ interface QueryInterface
      * It can be disabled by calling "highlight(FALSE)".
      *
      * @param integer|boolean $fragmentSize The result fragment size for highlight snippets. If this parameter is FALSE, highlighting will be disabled.
-     * @param integer $fragmentCount The number of highlight fragments to show.
+     * @param int|null $fragmentCount The number of highlight fragments to show.
+     * @param int $noMatchSize
+     * @param string $field
      * @return void
      * @api
      */
-    public function highlight($fragmentSize, int $fragmentCount = null): void;
+    public function highlight($fragmentSize, int $fragmentCount = null, int $noMatchSize = 150, string $field = 'neos_fulltext.*'): void;
 
     /**
      * This method is used to create any kind of aggregation.

--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -730,14 +730,16 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      * Configure Result Highlighting. Only makes sense in combination with fulltext(). By default, highlighting is enabled.
      * It can be disabled by calling "highlight(FALSE)".
      *
-     * @param integer|boolean $fragmentSize The result fragment size for highlight snippets. If this parameter is FALSE, highlighting will be disabled.
-     * @param integer $fragmentCount The number of highlight fragments to show.
+     * @param int|bool $fragmentSize The result fragment size for highlight snippets. If this parameter is FALSE, highlighting will be disabled.
+     * @param int|null $fragmentCount The number of highlight fragments to show.
+     * @param int $noMatchSize
+     * @param string $field
      * @return ElasticSearchQueryBuilder
      * @api
      */
-    public function highlight($fragmentSize, int $fragmentCount = null): ElasticSearchQueryBuilder
+    public function highlight($fragmentSize, int $fragmentCount = null, int $noMatchSize = 150, string $field = 'neos_fulltext.*'): ElasticSearchQueryBuilder
     {
-        $this->request->highlight($fragmentSize, $fragmentCount);
+        $this->request->highlight($fragmentSize, $fragmentCount, $noMatchSize, $field);
 
         return $this;
     }

--- a/README.md
+++ b/README.md
@@ -438,10 +438,26 @@ As **value**, the following methods accept a simple type, a node object or a Dat
 |`lessThanOrEqual('propertyName', value, [clauseType])`|Range filter with property values less than or equal to the given value|
 |`sortAsc('propertyName')` / `sortDesc('propertyName')`|Can also be used multiple times, e.g. `sortAsc('tag').sortDesc('date')` will first sort by tag ascending, and then by date descending.|
 |`limit(5)`                                            |Only return five results. If not specified, the default limit by Elasticsearch applies (which is at 10 by default)|
-|`from(5)`                                             |Return the results starting from the 6th one|
-|`prefix('propertyName', 'prefix', [clauseType])`      |Adds a prefix filter on the given field with the given prefix|
-|`geoDistance(propertyName, geoPoint, distance, [clauseType])` |Filters documents that include only hits that exists within a specific distance from a geo point.|
-|`fulltext('searchWord', options)`                     |Does a query_string query on the Fulltext index using the searchword and additional [options](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/query-dsl-query-string-query.html) to the query_string|
+|`from(5)`                                                        |Return the results starting from the 6th one|
+|`prefix('propertyName', 'prefix', [clauseType])`                 |Adds a prefix filter on the given field with the given prefix|
+|`geoDistance(propertyName, geoPoint, distance, [clauseType])`.   |Filters documents that include only hits that exists within a specific distance from a geo point.|
+|`fulltext('searchWord', options)`                                |Does a query_string query on the Fulltext index using the searchword and additional [options](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/query-dsl-query-string-query.html) to the query_string|
+|`highlight(fragmentSize, fragmentCount, noMatchSize, field)`     |Configure result highlighting for every fulltext field individually|
+
+## Search Result Highlighting
+
+When using the `.fulltext()` oprtator to do a fulltext, **highlight snippets** ([elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/highlighting.html#highlighting)) are automatically queried. By default snippets with 150 characters are queried for all available fulltext fields with a 150 character fallback text. 
+
+To adjust this behavior you can first deactivate the default and then configure highlighting for every field individually:
+
+	Search.highlight(false).highlight(150, 2, 150, 'neos_fulltext.text').highlight(100, 1, 0, 'neos_fulltext.h2')
+
+This deactivates the default highlighting and then queries 2 snipets of 150 characters each from hits in `neos_fulltext.text`, with a fallback to 150 charchters of the beginning of the text if no match was found and additional 100 characters from `neos_fulltext.h2` without a fallback.
+
+The highlight snippets can be accessed by
+
+	highlight = ${Search(...).execute().searchHitForNode(node).highlight}
+
 
 ## moreLikeThis(like, fields, options)
 


### PR DESCRIPTION
Previously you only could define the highlighting for all fields
and no_match_size was automatically active. Now the parameters can be configured
individually by field.