### PR TITLE
fix: convert all DateTime instances to string

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -1054,7 +1054,7 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
             return $value->getIdentifier();
         }
 
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             return $value->format('Y-m-d\TH:i:sP');
         }
 


### PR DESCRIPTION
The `convertValue()` method now converts also `DateTimeImmutable` instead of only `DateTime`.