### PR TITLE
BUGFIX: ElasticSearchQueryBuilder removes json encode generated quotes

### DIFF
--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -684,8 +684,11 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
      */
     public function fulltext(string $searchWord, array $options = []): QueryBuilderInterface
     {
+        $encodedSearchWord = json_encode($searchWord, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        // remove quotes added by json_encode
+        $encodedSearchWord = \substr($encodedSearchWord, 1, \strlen($encodedSearchWord)-2);
         // We automatically enable result highlighting when doing fulltext searches. It is up to the user to use this information or not use it.
-        $this->request->fulltext(trim(json_encode($searchWord, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE), '"'), $options);
+        $this->request->fulltext($encodedSearchWord, $options);
         $this->request->highlight(150, 2);
 
         return $this;


### PR DESCRIPTION
By default the ES CR Adaptor uses [query_string](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax) which allows some search syntax in query string.

In the current implementation, `json_encode` is used on the query string which adds double quotes around the search term,
e.g. `brown fox` is json encoded to `"brown fox"`. Then `trim` is used to remove the `"`.

Since one can use double quotes in the search term itself, e.g. `"brown fox"` this results in json encoded `"\"brown fox\""`. If you use `trim` you get invalid json which causes an exception because of invalid syntax in the ES query: `\"brown fox\`.

This PR, just removes the outer quotes created by `json_encode`.