### PR TITLE
Bugfix: Should throw error if indexname is not set

### DIFF
--- a/Classes/ElasticSearchClient.php
+++ b/Classes/ElasticSearchClient.php
@@ -129,7 +129,7 @@ class ElasticSearchClient extends Client
     public function getIndexNamePrefix(): string
     {
         $name = trim($this->indexNameStrategy->get());
-        if ($name === '') {
+        if ($name === '' || $name == false) {
             throw new ConfigurationException('IndexNameStrategy ' . get_class($this->indexNameStrategy) . ' returned an empty index name', 1582538800);
         }
 


### PR DESCRIPTION
It is common practice to use an ENV variable to set the index name. If it's not present,It is common practice to use an ENV variable to set the index name. If it's not present, `$name` is not empty string, but `false`. 

I know this is likely not a bug in the Adaptor itself, maybe let's see this as an enhancement 😄  $name is not empty string, but false.