### PR TITLE
BUGFIX: use correct context for document-identifier

### DIFF
--- a/Classes/Service/DocumentIdentifier/NodeIdentifierBasedDocumentIdentifierGenerator.php
+++ b/Classes/Service/DocumentIdentifier/NodeIdentifierBasedDocumentIdentifierGenerator.php
@@ -14,14 +14,19 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Service\DocumentIdenti
  */
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Utility\NodePaths;
 
 class NodeIdentifierBasedDocumentIdentifierGenerator implements DocumentIdentifierGeneratorInterface
 {
     public function generate(NodeInterface $node, ?string $targetWorkspaceName = null): string
     {
-        $workspaceName = $targetWorkspaceName ?: $node->getWorkspace()->getName();
+        $nodeContext = $node->getContext();
+
+        $workspaceName = $targetWorkspaceName ?: $nodeContext->getWorkspace()->getName();
         $nodeIdentifier = $node->getIdentifier();
 
-        return sha1($nodeIdentifier . $workspaceName);
+        $identifier = NodePaths::generateContextPath($nodeIdentifier, $workspaceName, $nodeContext->getDimensions());
+
+        return sha1($identifier);
     }
 }


### PR DESCRIPTION
## Problem
The current implementation falls back to the workspace name of the node (i.e. the value of the underlying NodeData), which in most cases is "live", generating the same document-identifier when indexing separate workspaces, thus always updating the same elasticsearch document with a new workspace. Because of that only the last indexed workspace would have nodes in the index and querying "live" would most likely not find results.

## Implementation
The `NodePathBasedDocumentIdentifierGenerator` uses the context-path of the node and _might_ replace the workspace with the given `$targetWorkspaceName`. In general that would leave the user-workspace as is: the context-path in the node is built from the workspace-name from the node context rather than the workspace name of the NodeData object.

The `NodeIdentifierBasedDocumentIdentifierGenerator` now also uses the node context values.

As the "original" solution would also include the dimensions, I added them as well: I utilized the NodePaths utility to format workspace-name and dimensions. I see how it might be debatable to misuse the utility and I guess it's not really necessary to match the format, so that could be changed, if preferred.

Relates to #394 