### PR TITLE
Draft: Feature elasticsearch 8 support

### DIFF
--- a/Classes/Driver/Version8/DocumentDriver.php
+++ b/Classes/Driver/Version8/DocumentDriver.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version8;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\AbstractDriver;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\DocumentDriverInterface;
+use Flowpack\ElasticSearch\Domain\Model\Index;
+use Flowpack\ElasticSearch\Domain\Model\Mapping;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Log\Utility\LogEnvironment;
+
+/**
+ * Document driver for Elasticsearch version 8.x
+ *
+ * @Flow\Scope("singleton")
+ */
+class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(NodeInterface $node, string $identifier): array
+    {
+        return [
+            [
+                'delete' => [
+                    '_id' => $identifier
+                ]
+            ]
+        ];
+    }
+}

--- a/Classes/Driver/Version8/IndexerDriver.php
+++ b/Classes/Driver/Version8/IndexerDriver.php
@@ -1,0 +1,158 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version8;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\AbstractIndexerDriver;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\IndexerDriverInterface;
+use Flowpack\ElasticSearch\Domain\Model\Document as ElasticSearchDocument;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Log\Utility\LogEnvironment;
+
+/**
+ * Indexer driver for Elasticsearch version 8.x
+ *
+ * @Flow\Scope("singleton")
+ */
+class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterface
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function document(string $indexName, NodeInterface $node, ElasticSearchDocument $document, array $documentData): array
+    {
+        if ($this->isFulltextRoot($node)) {
+            // for fulltext root documents, we need to preserve the "neos_fulltext" field. That's why we use the
+            // "update" API instead of the "index" API, with a custom script internally; as we
+            // shall not delete the "neos_fulltext" part of the document if it has any.
+            return [
+                [
+                    'update' => [
+                        '_id' => $document->getId(),
+                        '_index' => $indexName,
+                        'retry_on_conflict' => 3
+                    ]
+                ],
+                // http://www.elasticsearch.org/guide/en/elasticsearch/reference/5.0/docs-update.html
+                [
+                    'script' => [
+                        'lang' => 'painless',
+                        'source' => '
+                            HashMap fulltext = (ctx._source.containsKey("neos_fulltext") && ctx._source.neos_fulltext instanceof Map ? ctx._source.neos_fulltext : new HashMap());
+                            HashMap fulltextParts = (ctx._source.containsKey("neos_fulltext_parts") && ctx._source.neos_fulltext_parts instanceof Map ? ctx._source.neos_fulltext_parts : new HashMap());
+                            ctx._source = params.newData;
+                            ctx._source.neos_fulltext = fulltext;
+                            ctx._source.neos_fulltext_parts = fulltextParts',
+                        'params' => [
+                            'newData' => $documentData
+                        ]
+                    ],
+                    'upsert' => $documentData
+                ]
+            ];
+        }
+
+        // non-fulltext-root documents can be indexed as-they-are
+        return [
+            [
+                'index' => [
+                    '_id' => $document->getId(),
+                    '_index' => $indexName,
+                ]
+            ],
+            $documentData
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     * @param NodeInterface $node
+     * @param array $fulltextIndexOfNode
+     * @param string|null $targetWorkspaceName
+     * @return array
+     */
+    public function fulltext(NodeInterface $node, array $fulltextIndexOfNode, string $targetWorkspaceName = null): array
+    {
+        $closestFulltextNode = $this->findClosestFulltextRoot($node);
+        if ($closestFulltextNode === null) {
+            return [];
+        }
+
+        $closestFulltextNodeDocumentIdentifier = $this->documentIdentifierGenerator->generate($closestFulltextNode, $targetWorkspaceName);
+
+        if ($closestFulltextNode->isRemoved()) {
+            // fulltext root is removed, abort silently...
+            $this->logger->debug(sprintf('NodeIndexer (%s): Fulltext root found for %s (%s) not updated, it is removed', $closestFulltextNodeDocumentIdentifier, $node->getPath(), $node->getIdentifier()), LogEnvironment::fromMethodName(__METHOD__));
+
+            return [];
+        }
+
+        $upsertFulltextParts = [];
+        if (!empty($fulltextIndexOfNode)) {
+            $upsertFulltextParts[$node->getIdentifier()] = $fulltextIndexOfNode;
+        }
+
+        return [
+            [
+                'update' => [
+                    '_id' => $closestFulltextNodeDocumentIdentifier
+                ]
+            ],
+            // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html
+            [
+                // first, update the neos_fulltext_parts, then re-generate the neos_fulltext from all neos_fulltext_parts
+                'script' => [
+                    'lang' => 'painless',
+                    'source' => '
+                        ctx._source.neos_fulltext = new HashMap();
+                        if (!ctx._source.containsKey("neos_fulltext_parts") || !(ctx._source.neos_fulltext_parts instanceof Map)) {
+                            ctx._source.neos_fulltext_parts = new HashMap();
+                        }
+
+                        if (params.nodeIsRemoved || params.nodeIsHidden || params.fulltext.size() == 0) {
+                            if (ctx._source.neos_fulltext_parts.containsKey(params.identifier)) {
+                                ctx._source.neos_fulltext_parts.remove(params.identifier);
+                            }
+                        } else {
+                            ctx._source.neos_fulltext_parts.put(params.identifier, params.fulltext);
+                        }
+
+                        for (fulltextPart in ctx._source.neos_fulltext_parts.entrySet()) {
+                            for (entry in fulltextPart.getValue().entrySet()) {
+                                def value = "";
+                                if (ctx._source.neos_fulltext.containsKey(entry.getKey())) {
+                                    value = ctx._source.neos_fulltext[entry.getKey()] + " " + entry.getValue().trim();
+                                } else {
+                                    value = entry.getValue().trim();
+                                }
+                                ctx._source.neos_fulltext[entry.getKey()] = value;
+                            }
+                        }',
+                    'params' => [
+                        'identifier' => $node->getIdentifier(),
+                        'nodeIsRemoved' => $node->isRemoved(),
+                        'nodeIsHidden' => $node->isHidden(),
+                        'fulltext' => $fulltextIndexOfNode
+                    ],
+                ],
+                'upsert' => [
+                    'neos_fulltext' => $fulltextIndexOfNode,
+                    'neos_fulltext_parts' => $upsertFulltextParts
+                ]
+            ]
+        ];
+    }
+}

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -80,3 +80,65 @@ Flowpack:
             nodeTypeMappingBuilder:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Mapping\NodeTypeMappingBuilder'
           7.x: *v6x
+          8.x:
+            query:
+              className: Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Query\FilteredQuery
+              arguments:
+                request:
+                  query:
+                    bool:
+                      must:
+                        - match_all:
+                            boost: 1.0 # force match_all to be an object
+                      filter:
+                        bool:
+                          must: []
+                          should: []
+                          must_not:
+                            - term:
+                                neos_hidden: true
+                            - range:
+                                neos_hidden_before_datetime:
+                                  gt: now
+                            - range:
+                                neos_hidden_after_datetime:
+                                  lt: now
+                  _source:
+                    - 'neos_path'
+
+                unsupportedFieldsInCountRequest:
+                  - '_source'
+                  - 'sort'
+                  - 'from'
+                  - 'size'
+                  - 'highlight'
+                  - 'aggs'
+                  - 'aggregations'
+                  - 'suggest'
+
+                # Parameters for the query string query used by the fullText() and simpleQueryStringFulltext() operation
+                # See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-multi-field
+                # for all available parameters
+                queryStringParameters:
+                  default_operator: or
+                  fields:
+                    - neos_fulltext.h1^20
+                    - neos_fulltext.h2^12
+                    - neos_fulltext.h3^10
+                    - neos_fulltext.h4^5
+                    - neos_fulltext.h5^3
+                    - neos_fulltext.h6^2
+                    - neos_fulltext.text^1
+
+            document:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version8\DocumentDriver'
+            indexer:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version8\IndexerDriver'
+            indexManagement:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\IndexDriver'
+            request:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\RequestDriver'
+            system:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\SystemDriver'
+            nodeTypeMappingBuilder:
+              className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Mapping\NodeTypeMappingBuilder'

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This following matrix shows the compatibility of this package to Elasticsearch a
 | 5        | > 3.3, 4.x    | 5.x           | Bugfix only  | 
 | 6        | 5.x           | 5.x           | Bugfix only  |
 | 7        | 5.x           | 6.x, 7.x      | Bugfix and Features ([Upgrade Instructions](Documentation/Upgrade-6-to-7.md)) |
-| 8        | 7.x, 8.x      | 6.x, 7.x      | Bugfix and Features |
+| 8        | 7.x, 8.x      | 6.x, 7.x, 8.x | Bugfix and Features |
 
 _Currently the Driver interfaces are not marked as API, and can be changed to adapt to future needs._
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This following matrix shows the compatibility of this package to Elasticsearch a
 | 7        | 5.x           | 6.x, 7.x      | Bugfix and Features ([Upgrade Instructions](Documentation/Upgrade-6-to-7.md)) |
 | 8        | 7.x, 8.x      | 6.x, 7.x, 8.x | Bugfix and Features |
 
+Make sure to set the `Flowpack.ElasticSearch.ContentRepositoryAdaptor.driver.version` to '8.x' for ElasticSearch 8.
+
 _Currently the Driver interfaces are not marked as API, and can be changed to adapt to future needs._
 
 ### Elasticsearch Configuration file elasticsearch.yml


### PR DESCRIPTION
As Elasticsearch 8 has removed types the _type property must be removed from the indexing. Everything else appears to have stayed the same. I have not yet had time to test this in detail, however it appears to work with a simple instance we are currently building. I am opening this so that hopefully noone needs to duplicate work.

Unfortunately for this to work we also need to adapt the Flowpack.Elasticsearch/Domain/Model/Mapping to remove the 'include_type_name' option. This is a much larger issue however.