### PR TITLE
FEATURE: Make the adapter Elasticsearch 8 compatible

### DIFF
--- a/Classes/Driver/Version6/DocumentDriver.php
+++ b/Classes/Driver/Version6/DocumentDriver.php
@@ -37,7 +37,6 @@ class DocumentDriver extends AbstractDriver implements DocumentDriverInterface
         return [
             [
                 'delete' => [
-                    '_type' =>'_doc',
                     '_id' => $identifier
                 ]
             ]

--- a/Classes/Driver/Version6/IndexerDriver.php
+++ b/Classes/Driver/Version6/IndexerDriver.php
@@ -41,7 +41,6 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
             return [
                 [
                     'update' => [
-                        '_type' => '_doc',
                         '_id' => $document->getId(),
                         '_index' => $indexName,
                         'retry_on_conflict' => 3
@@ -70,7 +69,6 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
         return [
             [
                 'index' => [
-                    '_type' => '_doc',
                     '_id' => $document->getId(),
                     '_index' => $indexName,
                 ]
@@ -110,7 +108,6 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
         return [
             [
                 'update' => [
-                    '_type' => '_doc',
                     '_id' => $closestFulltextNodeDocumentIdentifier
                 ]
             ],

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -80,3 +80,4 @@ Flowpack:
             nodeTypeMappingBuilder:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version6\Mapping\NodeTypeMappingBuilder'
           7.x: *v6x
+          8.x: *v6x

--- a/Tests/Functional/BaseElasticsearchContentRepositoryAdapterTest.php
+++ b/Tests/Functional/BaseElasticsearchContentRepositoryAdapterTest.php
@@ -18,7 +18,6 @@ use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilde
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Tests\FunctionalTestCase;
-use function RectorPrefix202304\dump;
 
 abstract class BaseElasticsearchContentRepositoryAdapterTest extends FunctionalTestCase
 {

--- a/Tests/Functional/BaseElasticsearchContentRepositoryAdapterTest.php
+++ b/Tests/Functional/BaseElasticsearchContentRepositoryAdapterTest.php
@@ -18,6 +18,7 @@ use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Eel\ElasticSearchQueryBuilde
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
 use Neos\Flow\Tests\FunctionalTestCase;
+use function RectorPrefix202304\dump;
 
 abstract class BaseElasticsearchContentRepositoryAdapterTest extends FunctionalTestCase
 {
@@ -58,7 +59,13 @@ abstract class BaseElasticsearchContentRepositoryAdapterTest extends FunctionalT
 
         if (!$this->isIndexInitialized()) {
             // clean up any existing indices
-            $this->searchClient->request('DELETE', '/' . self::TESTING_INDEX_PREFIX . '*');
+            $aliases = $this->searchClient->request('GET', '_aliases')->getTreatedContent();
+
+            foreach ($aliases as $alias => $aliasConfiguration) {
+                if(str_starts_with($alias, self::TESTING_INDEX_PREFIX)) {
+                    $this->searchClient->request('DELETE', '/' . $alias);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- Remove _type argument, which is not needed for modern ES versions
- Fix removing of all indices in tests. Wildcard removal is not supported on Elasticsearch 8
- Add an alias for 8.x driver