### PR TITLE
Bugfix: Use workspace name from context

### DIFF
--- a/Classes/Service/DocumentIdentifier/NodeIdentifierBasedDocumentIdentifierGenerator.php
+++ b/Classes/Service/DocumentIdentifier/NodeIdentifierBasedDocumentIdentifierGenerator.php
@@ -19,7 +19,7 @@ class NodeIdentifierBasedDocumentIdentifierGenerator implements DocumentIdentifi
 {
     public function generate(NodeInterface $node, ?string $targetWorkspaceName = null): string
     {
-        $workspaceName = $targetWorkspaceName ?: $node->getWorkspace()->getName();
+        $workspaceName = $targetWorkspaceName ?: $node->getContext()->getWorkspace()->getName();
         $nodeIdentifier = $node->getIdentifier();
 
         return sha1($nodeIdentifier . $workspaceName);


### PR DESCRIPTION
@daniellienert implemented `NodeIdentifierBasedDocumentIdentifierGenerator` in #394, which works mostly fine. Except of a few cases where workspace names differ while publishing. 

#404 describes the same problem. Some of our tests showed up, that getting the workspace-name form the nodes context, helps out here. We stumbled over #404, which also includes dimension-values in the identifier. But this is not needed, since there are different ES indices per dimension-combination. So we do not need an additional info about the dimension inside the identifier. 

@daniellienert  and I have already discussed this change once via Slack and came to the conclusion that this is a logical fix. We then successfully tested this in customer projects. 

This change should appear as a minor release. It is semi-breaking. If you use the optional identifier from #394, you should start a reindexing afterwards to avoid possible duplications in the index. However, the existing index remains usable. All other users are not affected by this fix.