### PR TITLE
BUGFIX: Skip content with hidden parent nodes in fulltext index

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -243,6 +243,16 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
                 }
             }
 
+            // Don't index node into fulltext if it has a hidden parent node that is not a fulltext root
+            // Example: If a text node is in a hidden container element, it should not be indexed into the document
+            $parentNode = $node;
+            while (($parentNode = $parentNode->getParent())
+                && !$parentNode->getNodeType()->getConfiguration('search.fulltext.isRoot')) {
+                if (!$parentNode->isVisible()) {
+                    return;
+                }
+            }
+
             $documentIdentifier = $this->documentIdentifierGenerator->generate($node, $targetWorkspaceName);
             $nodeType = $node->getNodeType();
 


### PR DESCRIPTION
With this change nodes with hidden parents of type content are skipped during indexing. 
By checking the visible state, the hidden flag and the time based visibility are checked.
Document nodes, which are full text roots are already checked, so we don't need to traverse the tree to the site node.
The performance impact should be negligible as the parent nodes are usually already in the cache.

As the fulltext indexing is a snapshot to make the time based visibility fully work. There needs to be a scheduled reindexing.

Relates: #214 #377