### PR TITLE
BUGFIX: Retry on conflict also in fulltext method and make number of retries configurable

### DIFF
--- a/Classes/Driver/Version6/IndexerDriver.php
+++ b/Classes/Driver/Version6/IndexerDriver.php
@@ -28,6 +28,11 @@ use Neos\Flow\Log\Utility\LogEnvironment;
  */
 class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterface
 {
+    /**
+     * @Flow\InjectConfiguration(path="indexing.retryOnConflict")
+     * @var int
+     */
+    protected $retryOnConflict = 3;
 
     /**
      * {@inheritdoc}
@@ -43,7 +48,7 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
                     'update' => [
                         '_id' => $document->getId(),
                         '_index' => $indexName,
-                        'retry_on_conflict' => 3
+                        'retry_on_conflict' => $this->retryOnConflict ?: 3
                     ]
                 ],
                 // https://www.elastic.co/guide/en/elasticsearch/reference/5.0/docs-update.html
@@ -71,6 +76,7 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
                 'index' => [
                     '_id' => $document->getId(),
                     '_index' => $indexName,
+                    'retry_on_conflict' => $this->retryOnConflict ?: 3
                 ]
             ],
             $documentData
@@ -108,7 +114,8 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
         return [
             [
                 'update' => [
-                    '_id' => $closestFulltextNodeDocumentIdentifier
+                    '_id' => $closestFulltextNodeDocumentIdentifier,
+                    'retry_on_conflict' => $this->retryOnConflict ?: 3
                 ]
             ],
             // https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,7 @@ Flowpack:
       command:
         useSubProcesses: true
       indexing:
+        retryOnConflict: 3
         batchSize:
           elements: 500
           octets: 40000000


### PR DESCRIPTION
We had issues (see below) with version conflicts in ElasticSearch. We first noticed it after a major ES version upgrade on our server. And I think I finally found a solution. One the one hand by adding `retryOnConflict` parameter also in the `fulltext` method, but also by making the number of retries configurable.

As far as I understand this is happening, because the painless script increases the ES document version, which leads the following the request to fail, even though there is no real concurrency.

```json
{
    "update": {
        "_index": "xxx-production-default-1748641843",
        "_type": "_doc",
        "_id": "0c32c7170b89614b754749aceb810a0649d9ccb4",
        "status": 409,
        "error": {
            "type": "version_conflict_engine_exception",
            "reason": "[0c32c7170b89614b754749aceb810a0649d9ccb4]: version conflict, required seqNo [49036], primary term [1]. current document has seqNo [49039] and primary term [1]",
            "index_uuid": "-1GzR6SVSASUgeS_xdPXnQ",
            "shard": "0",
            "index": "xxx-production-default-1748641843"
        }
    }
}
```