### PR TITLE
BUGFIX: Find nodes in CR without security checks to allow nodes of other workspaces

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -154,7 +154,7 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
-    #[Flow\Inject()]
+    #[Flow\Inject]
     protected Context $securityContext;
 
     /** @var array<ContentRepository> */
@@ -276,10 +276,10 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
 
         $handleNode = function (Node $node, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint) use ($contentRepository, $targetWorkspaceName, $indexer, &$nodeFromContext) {
             $nodeFromContext = $this->securityContext->withoutAuthorizationChecks(
-                function () use ($contentRepository, $node, $workspaceName, $dimensionSpacePoint) {
-                    $subgraph = $contentRepository->getContentGraph($workspaceName)->getSubgraph($dimensionSpacePoint, VisibilityConstraints::withoutRestrictions());
-                    return $subgraph->findNodeById($node->aggregateId);
-                }
+                fn() => $contentRepository
+                    ->getContentGraph($workspaceName)
+                    ->getSubgraph($dimensionSpacePoint, VisibilityConstraints::withoutRestrictions())
+                    ->findNodeById($node->aggregateId)
             );
             if ($nodeFromContext instanceof Node) {
                 $this->searchClient->withDimensions(static function () use ($indexer, $nodeFromContext, $targetWorkspaceName) {

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -41,6 +41,7 @@ use Neos\ContentRepository\Search\Indexer\BulkNodeIndexerInterface;
 use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\Utility\LogEnvironment;
+use Neos\Flow\Security\Context;
 use Neos\Utility\Exception\FilesException;
 use Psr\Log\LoggerInterface;
 
@@ -152,6 +153,9 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
 
     #[Flow\Inject]
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
+
+    #[Flow\Inject()]
+    protected Context $securityContext;
 
     /** @var array<ContentRepository> */
     private array $contentRepositoryRuntimeCache = [];
@@ -270,10 +274,13 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
             }
         };
 
-        $handleNode = function (Node $node, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint) use ($contentRepository, $targetWorkspaceName, $indexer) {
-            $subgraph = $contentRepository->getContentGraph($workspaceName)->getSubgraph($dimensionSpacePoint, VisibilityConstraints::withoutRestrictions());
-            $nodeFromContext = $subgraph->findNodeById($node->aggregateId);
-
+        $handleNode = function (Node $node, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint) use ($contentRepository, $targetWorkspaceName, $indexer, &$nodeFromContext) {
+            $nodeFromContext = $this->securityContext->withoutAuthorizationChecks(
+                function () use ($contentRepository, $node, $workspaceName, $dimensionSpacePoint) {
+                    $subgraph = $contentRepository->getContentGraph($workspaceName)->getSubgraph($dimensionSpacePoint, VisibilityConstraints::withoutRestrictions());
+                    return $subgraph->findNodeById($node->aggregateId);
+                }
+            );
             if ($nodeFromContext instanceof Node) {
                 $this->searchClient->withDimensions(static function () use ($indexer, $nodeFromContext, $targetWorkspaceName) {
                     $indexer($nodeFromContext, $targetWorkspaceName);


### PR DESCRIPTION
When the nodes get indexed by the RealTimeCatchUpHook it might happen, the projection caugt up events of a different user/workspace. So the indexing must run without security checks.