### PR TITLE
BUGFIX: Find nodes in CR without security checks to allow nodes of other workspaces

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -277,9 +277,10 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
         };
 
         $handleNode = function (NodeInterface $node, Context $context) use ($targetWorkspace, $indexer) {
-            $nodeFromContext = $this->securityContext->withoutAuthorizationChecks(
-                function () use ($context, $node) {
-                    return $context->getNodeByIdentifier($node->getIdentifier());
+            $nodeFromContext = null;
+            $this->securityContext->withoutAuthorizationChecks(
+                function () use ($context, $node, &$nodeFromContext) {
+                    $nodeFromContext = $context->getNodeByIdentifier($node->getIdentifier());
                 }
             );
             if ($nodeFromContext instanceof NodeInterface) {


### PR DESCRIPTION
Backport of #419 to Neos 8.x

This wraps the getNodeByIdentifier() call in withoutAuthorizationChecks() to prevent workspace-related authorization checks from failing when indexing nodes that exist in different workspaces.

Resolves the error: Node workspace "user-xxx" not found in allowed workspaces (live), this could result from a detached workspace entity in the context.