### PR TITLE
TASK: adjust handling of node property of type reference in maping generation

### DIFF
--- a/Classes/Driver/Version6/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version6/Mapping/NodeTypeMappingBuilder.php
@@ -73,8 +73,10 @@ class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
 
             $propertiesAndReferences = array_merge(
                 $nodeType->getProperties(),
-                array_map(function ($reference) {
-                    $reference['type'] = 'references';
+                array_map(static function (array $reference): array {
+                    $reference['type'] = (($reference['constraints']['maxItems'] ?? null) === 1)
+                        ? 'reference'
+                        : 'references';
                     return $reference;
                 }, $nodeType->getReferences())
             );


### PR DESCRIPTION
Currently node properties of type reference are not indexed correctly. In the index the corresponding fields are empty arrays. This adjustment fixes the handling of properties of type reference in the mapping generation. See also the companion pr here https://github.com/neos/content-repository-search/pull/59