### PR TITLE
BUGFIX: Skip nodes with non-existing nodetypes

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -227,8 +227,9 @@ class NodeIndexer extends AbstractNodeIndexer implements BulkNodeIndexerInterfac
     {
         $contentRepository = $this->getCachedContentRepositoryByContentRepositoryId($node->contentRepositoryId);
 
-        if ($this->nodeTypeIndexingConfiguration->isIndexable($contentRepository->getNodeTypeManager()->getNodeType($node->nodeTypeName)) === false) {
-            $this->logger->debug(sprintf('Node "%s" (%s) skipped, Node Type is not allowed in the index.', NodeAddress::fromNode($node)->toJson(), $contentRepository->getNodeTypeManager()->getNodeType($node->nodeTypeName)->name->value), LogEnvironment::fromMethodName(__METHOD__));
+        $nodeType = $contentRepository->getNodeTypeManager()->getNodeType($node->nodeTypeName);
+        if (!$nodeType || $this->nodeTypeIndexingConfiguration->isIndexable($nodeType) === false) {
+            $this->logger->debug(sprintf('Node "%s" (%s) skipped, Node Type is not allowed in the index.', NodeAddress::fromNode($node)->toJson(), $node->nodeTypeName), LogEnvironment::fromMethodName(__METHOD__));
             return;
         }
 


### PR DESCRIPTION
Before this change, the indexer crashed with an error as `isIndexable` required a valid NodeType instance, but `getNodeType` can return `null`.

Now the node with the unknown nodetype is skipped and the problem is logged with the raw name of the problematic nodetype.