### PR TITLE
BUGFIX: Allow indexing and cleanup of non-default CRs via CLI

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -232,11 +232,10 @@ class NodeIndexCommandController extends CommandController
      * @throws ConfigurationException
      * @throws ApiException
      */
-    public function buildCommand(?int $limit = null, bool $update = false, ?string $workspace = null, ?string $postfix = null): void
+    public function buildCommand(?int $limit = null, bool $update = false, string $contentRepository = 'default', ?string $workspace = null, ?string $postfix = null): void
     {
-        $contentRepositoryId = ContentRepositoryId::fromString('default');
         $workspaceName = $workspace ? WorkspaceName::fromString($workspace) : null;
-        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $contentRepository = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString($contentRepository));
 
         $this->logger->info(sprintf('Starting elasticsearch indexing %s sub processes', $this->useSubProcesses ? 'with' : 'without'), LogEnvironment::fromMethodName(__METHOD__));
 
@@ -274,7 +273,6 @@ class NodeIndexCommandController extends CommandController
                 'update' => $update,
             ]);
         };
-        $contentRepository = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString('default'));
         $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
 
         $runAndLog = function ($command, string $stepInfo) use ($dimensionSpacePoints) {

--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -502,10 +502,10 @@ class NodeIndexCommandController extends CommandController
      * @throws ConfigurationException
      * @throws Exception
      */
-    public function cleanupCommand(): void
+    public function cleanupCommand(string $contentRepository = 'default'): void
     {
         $removed = false;
-        $contentRepository = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString('default'));
+        $contentRepository = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString($contentRepository));
         $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
         foreach ($dimensionSpacePoints as $dimensionSpacePoint) {
             try {


### PR DESCRIPTION
The other commands already had the option to provide a custom CR id, the build and cleanup commands were missing it.